### PR TITLE
Feature/eth fee history

### DIFF
--- a/src/net/http/jsonrpc/call.cpp
+++ b/src/net/http/jsonrpc/call.cpp
@@ -54,6 +54,8 @@ json call(const json& request, State& state, const Storage& storage,
       result = jsonrpc::eth_estimateGas(request, storage, state);
     else if (method == "eth_gasPrice")
       result = jsonrpc::eth_gasPrice(request);
+    else if (method == "eth_feeHistory")
+      result = jsonrpc::eth_feeHistory(request, storage);
     else if (method == "eth_getLogs")
       result = jsonrpc::eth_getLogs(request, storage, state);
     else if (method == "eth_getBalance")

--- a/src/net/http/jsonrpc/error.h
+++ b/src/net/http/jsonrpc/error.h
@@ -3,7 +3,6 @@
 
 #include <string_view>
 #include <stdexcept>
-#include <format>
 
 namespace jsonrpc {
 
@@ -31,13 +30,13 @@ public:
   /// @brief constructs a "invalid type" parsing error
   /// @return the error object with a user friendly message
   static Error invalidType(std::string_view exp, std::string_view got) {
-    return Error(-32601, std::format("Parsing error: invalid type, exp '{}' - got '{}'", exp, got));
+    return Error(-32601, "Parsing error: invalid type, exp '" + std::string(exp) + "' - got '" + std::string(got) + "'");
   }
 
   /// @brief constructs a "invalid format" parsing error
   /// @return the error object with a user friendly message
   static Error invalidFormat(std::string_view wrong) {
-    return Error(-32601, std::format("Parsing error: '{}' is in invalid format", wrong));
+    return Error(-32601, "Parsing error: '" + std::string(wrong) + "' is in invalid format");
   }
 
   /// @brief constructs a "insufficient values" parsing error for arrays
@@ -48,7 +47,7 @@ public:
 
   /// @brief constructs a generic interal exection error
   /// @return the error object with a user friendly message
-  static Error exectionError(std::string_view cause) {
+  static Error executionError(std::string_view cause) {
     return Error(-32603, std::string("Execution error: ") + cause.data());
   }
 };

--- a/src/net/http/jsonrpc/methods.h
+++ b/src/net/http/jsonrpc/methods.h
@@ -98,6 +98,8 @@ json eth_estimateGas(const json& request, const Storage& storage, State& state);
 
 json eth_gasPrice(const json& request);
 
+json eth_feeHistory(const json& request, const Storage& storage);
+
 json eth_getLogs(const json& request, const Storage& storage, const State& state);
 
 json eth_getBalance(const json& request, const Storage& storage, const State& state);

--- a/src/net/http/jsonrpc/parser.cpp
+++ b/src/net/http/jsonrpc/parser.cpp
@@ -50,6 +50,13 @@ bool Parser<bool>::operator()(const json& data) const {
   return data.get<bool>();
 }
 
+float Parser<float>::operator()(const json& data) const {
+  if (!data.is_number())
+    throw Error::invalidType("number", data.type_name());
+
+  return data.get<float>();
+}
+
 uint64_t Parser<uint64_t>::operator()(const json& data) const {
   if (data.is_number_unsigned())
     return data.get<uint64_t>();

--- a/tests/net/http/httpjsonrpc.cpp
+++ b/tests/net/http/httpjsonrpc.cpp
@@ -386,6 +386,19 @@ namespace THTTPJsonRPC{
         REQUIRE(eth_getTransactionReceiptResponse["result"]["root"] == Hash().hex(true));
         REQUIRE(eth_getTransactionReceiptResponse["result"]["status"] == "0x1");
       }
+
+      json eth_feeHistoryResponse = requestMethod("eth_feeHistory", json::array({ "0x2", "latest" }));
+      REQUIRE(eth_feeHistoryResponse["result"]["baseFeePerGas"][0] == "0x9502f900");
+      REQUIRE(eth_feeHistoryResponse["result"]["baseFeePerGas"][1] == "0x9502f900");
+      REQUIRE(eth_feeHistoryResponse["result"]["gasUsedRatio"][0] == 1.0); // TODO: properly compare float pointing values
+      REQUIRE(eth_feeHistoryResponse["result"]["gasUsedRatio"][1] == 1.0);
+      REQUIRE(eth_feeHistoryResponse["result"]["oldestBlock"] == "0x0");
+
+      eth_feeHistoryResponse = requestMethod("eth_feeHistory", json::array({ "0x1", "0x0" }));
+      REQUIRE(eth_feeHistoryResponse["result"]["baseFeePerGas"][0] == "0x9502f900");
+      REQUIRE(eth_feeHistoryResponse["result"]["baseFeePerGas"][1] == "0x9502f900");
+      REQUIRE(eth_feeHistoryResponse["result"]["gasUsedRatio"][0] == 1.0); // TODO: properly compare float pointing values
+      REQUIRE(eth_feeHistoryResponse["result"]["oldestBlock"] == "0x0");
     }
   }
 }


### PR DESCRIPTION
### `eth_feeHistory` implementation with mocked responses.

The overall structure is done, but we can't properly calculate the response values with the current block data. Therefore, `eth_feeHistory` will only return mocked values in the correct amount and format.