### PR TITLE
Remove Consensus::doValidatorBlock() requesting transactions

### DIFF
--- a/src/core/rdpos.h
+++ b/src/core/rdpos.h
@@ -68,6 +68,7 @@ class rdPoS : public BaseContract {
     State& state_;  ///< Reference to the blockchain state.
     std::set<Validator> validators_;  ///< Ordered list of rdPoS validators.
     std::vector<Validator> randomList_; ///< Shuffled version of the validator list, used at block creation/signing.
+    std::unordered_map<Hash, TxValidator, SafeHash> oooValidatorMempool_;  ///< Out-of-order mempool for validator transactions.
     std::unordered_map<Hash, TxValidator, SafeHash> validatorMempool_;  ///< Mempool for validator transactions.
     const PrivKey validatorKey_;  ///< Private key for operating a validator.
     const bool isValidator_ = false;  ///< Indicates whether node is a Validator.
@@ -115,6 +116,13 @@ class rdPoS : public BaseContract {
     bool isValidatorAddress(const Address& add) const { return validators_.contains(Validator(add)); }
 
     /**
+     * Check if a given Validator is participating in this round.
+     * @param validatorAddr Address of the Validator to check.
+     * @return `true` if the Validator is participating, `false` otherwise.
+     */
+    bool isValidatorParticipating(const Address& validatorAddr);
+
+    /**
      * Validate a block.
      * @param block The block to validate.
      * @return `true` if the block is properly validated, `false` otherwise.
@@ -157,7 +165,7 @@ class rdPoS : public BaseContract {
      * Clear the mempool
      * Used by tests
      */
-    void clearMempool() { this->validatorMempool_.clear(); }
+    void clearMempool() { this->validatorMempool_.clear(); this->oooValidatorMempool_.clear(); }
 
     /// Dump overriden function.
     DBBatch dump() const override;

--- a/tests/blockchainwrapper.hpp
+++ b/tests/blockchainwrapper.hpp
@@ -197,11 +197,11 @@ inline FinalizedBlock createValidBlock(const std::vector<Hash>& validatorPrivKey
   // Append the transactions to the block.
   std::vector<TxValidator> txsValidator;
   for (const auto& tx : randomHashTxs) {
-    state.rdposAddValidatorTx(tx);
+    REQUIRE(isTxStatusValid(state.rdposAddValidatorTx(tx)));
     txsValidator.emplace_back(tx);
   }
   for (const auto& tx : randomTxs) {
-    state.rdposAddValidatorTx(tx);
+    REQUIRE(isTxStatusValid(state.rdposAddValidatorTx(tx)));
     txsValidator.emplace_back(tx);
   }
 

--- a/tests/core/rdpos.cpp
+++ b/tests/core/rdpos.cpp
@@ -695,5 +695,8 @@ namespace TRdPoS {
     });
 
     REQUIRE(rdPoSBlockFuture.wait_for(std::chrono::seconds(60)) != std::future_status::timeout);
+
+    // FIXME: There is a hard-to-reproduce crash happening after this test ends, probably due to
+    //        incorrect lifetime management of ASIO callbacks/strands/handlers
   }
 };


### PR DESCRIPTION
This PR removes the need for the Consensus component to actively retrieve validator transactions from other validators (when the node is the block proposer) by adding an `oooValidatorMempool_` (out-of-order mempool) to the rdPoS engine.

The reason you would have to request validator transactions during new block production is because you received them in the past but tossed them away because they were early (in the testcases, this is always because they are one block ahead). Since the existing `validatorMempool_` in rdPoS is specifically for the working round, you can't store validator transactions that you receive that are not for that specific working round. So, a new mempool was created to store all of these, and when the chain advances, the OOO validator mempool is consulted for transactions that should be promoted to the main validator mempool -- as if it had just received those from the network, in the correct height.

This PR also deletes the code that makes Consensus request user transactions from other nodes. This should just not be done.