### PR TITLE
Add optional TEST_CHECK_TIME macro for tests

### DIFF
--- a/tests/core/state.cpp
+++ b/tests/core/state.cpp
@@ -1163,8 +1163,7 @@ namespace TState {
           }
         });
 
-        // Average time of above test is 3s; need a much larger timeout.
-        REQUIRE(confirmFuture.wait_for(std::chrono::seconds(120)) != std::future_status::timeout);
+        REQUIRE(TEST_CHECK_TIME(confirmFuture.wait_for(std::chrono::seconds(120)) != std::future_status::timeout, 5));
 
         // Check balances for target
         REQUIRE(blockchainWrapper1.state.getNativeBalance(targetOfTransactions) == targetExpectedValue);


### PR DESCRIPTION
This adds a TEST_CHECK_TIME (and a TEST_CHECK_TIME_VERBOSE) macro that can be used inside the REQURE() macro in tests.

These allow us to decouple a test correctness timeout (say, 3 minutes) from a soft test duration check.

Example: (in state.cpp)

```
REQUIRE(TEST_CHECK_TIME(confirmFuture.wait_for(std::chrono::seconds(120)) != std::future_status::timeout, 5));
```

This will fail the test if it takes more than 2 minutes to complete. However, if it takes more than 5 seconds to complete, it will print a warning. This allows us to keep an eye on test durations that may (or may not) accuse bugs or other problems we may want to fix or improve, without confusing those with correctness bugs.

Here's what it looks like when the assert fails; it is a bit uglier, but still understandable:

```
/home/fcecin/applayer/development/bdk-cpp/tests/core/state.cpp:1166: FAILED:
  REQUIRE( testCheckTime("/home/fcecin/applayer/development/bdk-cpp/tests/core/state.cpp", 1166, [&]() { return (confirmFuture.wait_for(std::chrono::seconds(1)) != std::future_status::timeout); }, 5, false) )
with expansion:
  false
```