### PR TITLE
Misc improvements and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(catch2
   ${CMAKE_SOURCE_DIR}/src/libs/catch2/catch_amalgamated.cpp
 )
 target_include_directories(catch2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/catch2)
+target_compile_definitions(catch2 PRIVATE CATCH_AMALGAMATED_CUSTOM_MAIN)
 
 # Check compiler variable sizes
 include(cmake/CheckSizes.cmake)

--- a/src/bins/bdkd-discovery/main.cpp
+++ b/src/bins/bdkd-discovery/main.cpp
@@ -5,20 +5,72 @@ This software is distributed under the MIT License.
 See the LICENSE.txt file in the project root for more information.
 */
 
+#include <csignal>
+#include <condition_variable>
+
 #include "net/p2p/managerdiscovery.h"
 #include "utils/options.h"
 #include "iostream"
+#include "src/utils/clargs.h"
+
+std::condition_variable cv;
+std::mutex cv_m;
+int signalCaught = 0;
+
+void signalHandler(int signum) {
+  {
+    std::unique_lock<std::mutex> lk(cv_m);
+    std::cout << std::endl << "Signal caught: " << Utils::getSignalName(signum) << std::endl;
+    signalCaught = signum;
+  }
+  cv.notify_one();
+}
 
 /// Executable with a discovery node for the given Options default chain.
-int main() {
+int main(int argc, char* argv[]) {
+  Utils::logToCout = true;
+  Utils::safePrint("bdkd-discovery: Blockchain Development Kit discovery node daemon");
+  std::signal(SIGINT, signalHandler);
+  std::signal(SIGHUP, signalHandler);
+
+  // Parse command-line options
+  ProcessOptions opt = parseCommandLineArgs(argc, argv, BDKTool::DISCOVERY_NODE);
+
+  // Select a default log level for this program if none is specified
+  if (opt.logLevel == "") opt.logLevel = "INFO";
+
+  // Apply selected process options
+  if (!applyProcessOptions(opt)) return 1;
+
+  // Start the discovery node
+  Utils::safePrint("Main thread starting node...");
   // Local binary path + /blockchain
   std::string blockchainPath = std::filesystem::current_path().string() + std::string("/discoveryNode");
   const auto options = Options::fromFile(blockchainPath);
-  P2P::ManagerDiscovery p2p(options.getP2PIp(), options);
-  p2p.start();
+  std::unique_ptr<P2P::ManagerDiscovery> p2p = std::make_unique<P2P::ManagerDiscovery>(options.getP2PIp(), options);
+  p2p->start();
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  p2p.startDiscovery();
-  // Sleep Forever
-  std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::hours(std::numeric_limits<int>::max()));
+  p2p->startDiscovery();
+
+  // Main thread waits for a non-zero signal code to be raised and caught
+  Utils::safePrint("Main thread waiting for interrupt signal...");
+  int exitCode = 0;
+  {
+    std::unique_lock<std::mutex> lk(cv_m);
+    cv.wait(lk, [] { return signalCaught != 0; });
+    exitCode = signalCaught;
+  }
+  Utils::safePrint("Main thread stopping due to interrupt signal [" + Utils::getSignalName(exitCode) + "], shutting down node...");
+
+  // Shut down the node
+  Logger::logToDebug(LogType::INFO, "MAIN", "MAIN", "Received signal " + std::to_string(exitCode));
+  Utils::safePrint("Main thread stopping node...");
+  p2p->stopDiscovery();
+  Utils::safePrint("Main thread shutting down...");
+  p2p.reset();
+
+  // Return the signal code
+  Utils::safePrint("Main thread exiting with code " + std::to_string(exitCode) + ".");
+  return exitCode;
 }
 

--- a/src/bins/bdkd/main.cpp
+++ b/src/bins/bdkd/main.cpp
@@ -8,29 +8,66 @@ See the LICENSE.txt file in the project root for more information.
 #include <iostream>
 #include <filesystem>
 
+#include <csignal>
+#include <condition_variable>
+
 #include "src/core/blockchain.h"
+#include "src/utils/clargs.h"
 
 std::unique_ptr<Blockchain> blockchain = nullptr;
 
-[[noreturn]] void signalHandler(int signum) {
-  Logger::logToDebug(LogType::INFO, "MAIN", "MAIN", "Received signal " + std::to_string(signum) + ". Stopping the blockchain.");
-  blockchain->stop();
-  blockchain = nullptr; // Destroy the blockchain object, calling the destructor of every module and dumping to DB.
-  Utils::safePrint("Exiting...");
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
-  exit(signum);
+std::condition_variable cv;
+std::mutex cv_m;
+int signalCaught = 0;
+
+void signalHandler(int signum) {
+  {
+    std::unique_lock<std::mutex> lk(cv_m);
+    std::cout << std::endl << "Signal caught: " << Utils::getSignalName(signum) << std::endl;
+    signalCaught = signum;
+  }
+  cv.notify_one();
 }
 
-int main() {
-
+int main(int argc, char* argv[]) {
   Utils::logToCout = true;
-  std::string blockchainPath = std::filesystem::current_path().string() + std::string("/blockchain");
-  blockchain = std::make_unique<Blockchain>(blockchainPath);
-  // Start the blockchain syncing engine.
+  Utils::safePrint("bdkd: Blockchain Development Kit full node daemon");
   std::signal(SIGINT, signalHandler);
   std::signal(SIGHUP, signalHandler);
-  blockchain->start();
-  std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::hours(std::numeric_limits<int>::max()));
-  return 0;
-}
 
+  // Parse command-line options
+  ProcessOptions opt = parseCommandLineArgs(argc, argv, BDKTool::FULL_NODE);
+
+  // Select a default log level for this program if none is specified
+  if (opt.logLevel == "") opt.logLevel = "INFO";
+
+  // Apply selected process options
+  if (!applyProcessOptions(opt)) return 1;
+
+  // Start the blockchain syncing engine.
+  Utils::safePrint("Main thread starting node...");
+  std::string blockchainPath = std::filesystem::current_path().string() + std::string("/blockchain");
+  blockchain = std::make_unique<Blockchain>(blockchainPath);
+  blockchain->start();
+
+  // Main thread waits for a non-zero signal code to be raised and caught
+  Utils::safePrint("Main thread waiting for interrupt signal...");
+  int exitCode = 0;
+  {
+    std::unique_lock<std::mutex> lk(cv_m);
+    cv.wait(lk, [] { return signalCaught != 0; });
+    exitCode = signalCaught;
+  }
+  Utils::safePrint("Main thread stopping due to interrupt signal [" + Utils::getSignalName(exitCode) + "], shutting down node...");
+
+  // Shut down the node
+  Logger::logToDebug(LogType::INFO, "MAIN", "MAIN", "Received signal " + std::to_string(exitCode));
+  Utils::safePrint("Main thread stopping node...");
+  blockchain->stop();
+  Utils::safePrint("Main thread shutting down...");
+  blockchain = nullptr; // Destroy the blockchain object, calling the destructor of every module and dumping to DB.
+
+  // Return the signal code
+  Utils::safePrint("Main thread exiting with code " + std::to_string(exitCode) + ".");
+  return exitCode;
+}

--- a/src/core/dump.cpp
+++ b/src/core/dump.cpp
@@ -48,7 +48,7 @@ std::pair<std::vector<DBBatch>, uint64_t> DumpManager::dumpState() const
     // or state changes are happening)
     blockHeight = storage_.latest()->getNHeight();
     // Emplace DBBatch operations
-    Logger::logToDebug(LogType::INFO,
+    Logger::logToDebug(LogType::DEBUG,
                        Log::dumpManager,
                        __func__,
                        "Emplace DBBatch operations");
@@ -110,6 +110,7 @@ DumpWorker::DumpWorker(const Options& options,
 
 DumpWorker::~DumpWorker()
 {
+  stopWorker();
   Logger::logToDebug(LogType::INFO, Log::dumpWorker, __func__, "DumpWorker Stopped.");
 }
 
@@ -118,7 +119,7 @@ bool DumpWorker::workerLoop()
   uint64_t latestBlock = this->storage_.currentChainSize();
   while (!this->stopWorker_) {
     if (latestBlock + this->options_.getStateDumpTrigger() < this->storage_.currentChainSize()) {
-      Logger::logToDebug(LogType::INFO,
+      Logger::logToDebug(LogType::DEBUG,
                          Log::dumpWorker,
                          __func__,
                          "Current size >= 100");

--- a/src/core/rdpos.cpp
+++ b/src/core/rdpos.cpp
@@ -208,7 +208,7 @@ Hash rdPoS::processBlock(const FinalizedBlock& block) {
 
 TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
   if (this->validatorMempool_.contains(tx.hash())) {
-    Logger::logToDebug(LogType::INFO, Log::rdPoS, __func__, "TxValidator already exists in mempool.");
+    Logger::logToDebug(LogType::TRACE, Log::rdPoS, __func__, "TxValidator already exists in mempool.");
     return TxStatus::ValidExisting;
   }
 
@@ -295,7 +295,7 @@ rdPoS::TxValidatorFunction rdPoS::getTxValidatorFunction(const TxValidator &tx) 
 DBBatch rdPoS::dump() const
 {
   DBBatch dbBatch;
-  Logger::logToDebug(LogType::INFO,
+  Logger::logToDebug(LogType::DEBUG,
                      Log::rdPoS,
                      __func__,
                      "Create batch operations.");

--- a/src/core/state.cpp
+++ b/src/core/state.cpp
@@ -160,7 +160,7 @@ TxStatus State::validateTransactionInternal(const TxBlock& tx) const {
 
   // Verify if transaction already exists within the mempool, if on mempool, it has been validated previously.
   if (this->mempool_.contains(tx.hash())) {
-    Logger::logToDebug(LogType::INFO, Log::state, __func__, "Transaction: " + tx.hash().hex().get() + " already in mempool");
+    Logger::logToDebug(LogType::TRACE, Log::state, __func__, "Transaction: " + tx.hash().hex().get() + " already in mempool");
     return TxStatus::ValidExisting;
   }
   auto accountIt = this->accounts_.find(tx.getFrom());
@@ -358,7 +358,7 @@ BlockValidationStatus State::validateNextBlockInternal(const FinalizedBlock& blo
     }
   }
 
-  Logger::logToDebug(LogType::INFO, Log::state, __func__,
+  Logger::logToDebug(LogType::TRACE, Log::state, __func__,
     "Block " + block.getHash().hex().get() + " is valid. (Sanity Check Passed)"
   );
   return BlockValidationStatus::valid;
@@ -428,7 +428,7 @@ TxStatus State::addTx(TxBlock&& tx) {
   std::unique_lock lock(this->stateMutex_);
   auto txHash = tx.hash();
   this->mempool_.insert({txHash, std::move(tx)});
-  Logger::logToDebug(LogType::INFO, Log::state, __func__, "Transaction: " + txHash.hex().get() + " was added to the mempool");
+  Logger::logToDebug(LogType::TRACE, Log::state, __func__, "Transaction: " + txHash.hex().get() + " was added to the mempool");
   return txResult; // should be TxStatus::ValidNew
 }
 

--- a/src/core/storage.cpp
+++ b/src/core/storage.cpp
@@ -340,7 +340,7 @@ std::shared_ptr<const FinalizedBlock> Storage::getBlock(const uint64_t& height) 
   std::shared_lock<std::shared_mutex> lockCache(this->cacheLock_);
   StorageStatus blockStatus = this->blockExistsInternal(height);
   if (blockStatus == StorageStatus::NotFound) return nullptr;
-  Logger::logToDebug(LogType::INFO, Log::storage, __func__, "height: " + std::to_string(height));
+  Logger::logToDebug(LogType::TRACE, Log::storage, __func__, "height: " + std::to_string(height));
   switch (blockStatus) {
     case StorageStatus::NotFound: {
       return nullptr;

--- a/src/net/p2p/managerbase.cpp
+++ b/src/net/p2p/managerbase.cpp
@@ -76,7 +76,7 @@ namespace P2P {
       (message->command() == CommandType::Info || message->command() == CommandType::RequestValidatorTxs)
     ) {
       lockSession.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      Logger::logToDebug(LogType::INFO, Log::P2PManager, __func__, "Session is discovery, cannot send message");
+      Logger::logToDebug(LogType::DEBUG, Log::P2PManager, __func__, "Session is discovery, cannot send message");
       return nullptr;
     }
     std::unique_lock lockRequests(this->requestsMutex_);
@@ -192,7 +192,8 @@ namespace P2P {
 
   void ManagerBase::ping(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::ping());
-    Utils::logToFile("Pinging " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
+    Logger::logToDebug(LogType::TRACE, Log::P2PParser, __func__,
+                       "Pinging " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
     auto requestPtr = sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) throw DynamicException(
       "Failed to send ping to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second)
@@ -204,7 +205,8 @@ namespace P2P {
   // Somehow change to wait_for.
   std::unordered_map<NodeID, NodeType, SafeHash> ManagerBase::requestNodes(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::requestNodes());
-    Utils::logToFile("Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
+    Logger::logToDebug(LogType::TRACE, Log::P2PParser, __func__,
+                       "Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
     auto requestPtr = sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
       Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__, "Request to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " failed.");

--- a/src/net/p2p/managernormal.cpp
+++ b/src/net/p2p/managernormal.cpp
@@ -349,7 +349,8 @@ namespace P2P{
   // Somehow change to wait_for.
   std::vector<TxValidator> ManagerNormal::requestValidatorTxs(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::requestValidatorTxs());
-    Utils::logToFile("Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
+    Logger::logToDebug(LogType::TRACE, Log::P2PParser, __func__,
+                       "Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
     auto requestPtr = this->sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
       Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,
@@ -378,7 +379,8 @@ namespace P2P{
 
   std::vector<TxBlock> ManagerNormal::requestTxs(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::requestTxs());
-    Utils::logToFile("Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
+    Logger::logToDebug(LogType::TRACE, Log::P2PParser, __func__,
+                       "Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
     auto requestPtr = this->sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
       Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,
@@ -407,7 +409,8 @@ namespace P2P{
 
   NodeInfo ManagerNormal::requestNodeInfo(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::info(this->storage_.latest(), this->nodeConns_.getConnectedWithNodeType(), this->options_));
-    Utils::logToFile("Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
+    Logger::logToDebug(LogType::TRACE, Log::P2PParser, __func__,
+                       "Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
     auto requestPtr = sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
       Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,

--- a/src/utils/clargs.h
+++ b/src/utils/clargs.h
@@ -1,0 +1,153 @@
+/*
+Copyright (c) [2023-2024] [AppLayer Developers]
+
+This software is distributed under the MIT License.
+See the LICENSE.txt file in the project root for more information.
+*/
+
+#ifndef CLARGS_H
+#define CLARGS_H
+
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
+
+#include "src/utils/logger.h"
+
+/**
+ * List of BDK programs that the argument parser is aware of.
+ */
+enum BDKTool {
+  FULL_NODE,
+  DISCOVERY_NODE,
+  UNIT_TEST_SUITE
+};
+
+/**
+ * Result of parsing command-line options for the node.
+ * Default option values should signal that they weren't set, either by command-line
+ * arguments or by the program itself.
+ */
+struct ProcessOptions {
+  bool valid = false;      ///< Set to true only if parameter parsing did not fail
+  std::string logLevel;    ///< Desired log level name
+  int logLineLimit = -1;   ///< Desired log line count limit for the rotating logger log file
+  int logFileLimit = -1;   ///< Desired log file hard limit (erases older log files past this count)
+};
+
+/**
+ * This function can be called from the main() function of any BDK node program to
+ * parse a set of command-line arguments. It does not check if the provided values
+ * are valid, only the expected argument count/type format.
+ * @param argc Forwarded argc from main().
+ * @param argv Forwarded argv from main().
+ * @param nodeType Which tool is taking args; can be used to determine which args are available.
+ * @return A ProcessOptions struct with the result of argument parsing.
+ */
+ProcessOptions parseCommandLineArgs(int argc, char* argv[], BDKTool tool) {
+  ProcessOptions opt;
+  try {
+
+    boost::program_options::options_description desc("Allowed options");
+    desc.add_options()
+        ("help,h", 
+          "Print help message and exit")
+        ("loglevel,l", boost::program_options::value<std::string>(), 
+          "Set the log level ([T]RACE, [D]EBUG, [I]NFO, [W]ARNING, [E]RROR, [N]NONE)")
+        ("loglinelimit", boost::program_options::value<int>(), 
+          "Set the log line limit for rotating the log file")
+        ("logfilelimit", boost::program_options::value<int>(), 
+          "Set the log file limit (erases older log files); 0 = no limit")
+        ;
+
+    boost::program_options::variables_map vm;
+    boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
+    boost::program_options::notify(vm);
+
+    if (vm.count("help")) {
+        std::cout << desc << "\n";
+        exit(0);
+    }
+
+    if (vm.count("loglevel")) {
+      opt.logLevel = vm["loglevel"].as<std::string>();
+    }
+
+    if (vm.count("loglinelimit")) {
+      opt.logLineLimit = vm["loglinelimit"].as<int>();
+      if (opt.logLineLimit < 0) {
+        std::cerr << "ERROR: --loglinelimit must be >= 0\n";
+        return {};
+      }
+    }
+
+    if (vm.count("logfilelimit")) {
+      opt.logFileLimit = vm["logfilelimit"].as<int>();
+      if (opt.logFileLimit < 0) {
+        std::cerr << "ERROR: --logfilelimit must be >= 0\n";
+        return {};
+      }
+    }
+
+  } catch (std::exception& e) {
+      std::cout << "ERROR: parseCommandLineArgs(): " << e.what() << "\n";
+      return {};
+  } catch (...) {
+      std::cout << "ERROR: parseCommandLineArgs(): Unknown exception\n";
+      return {};
+  }
+
+  opt.valid = true;
+  return opt;
+}
+
+/**
+ * This function provides a default way to apply a ProcessOptions object.
+ * @param opt Process Options object to apply.
+ * @return `true` if no error, `false` otherwise.
+ */
+bool applyProcessOptions(ProcessOptions& opt) {
+
+  if (!opt.valid) {
+    std::cout << "ERROR: Invalid command-line arguments." << std::endl;
+    return false;
+  }
+
+  boost::to_upper(opt.logLevel);
+
+  if (opt.logLevel == "T") { opt.logLevel = "TRACE"; }
+  else if (opt.logLevel == "D") { opt.logLevel = "DEBUG"; }
+  else if (opt.logLevel == "I") { opt.logLevel = "INFO"; }
+  else if (opt.logLevel == "W") { opt.logLevel = "WARNING"; }
+  else if (opt.logLevel == "E") { opt.logLevel = "ERROR"; }
+  else if (opt.logLevel == "N") { opt.logLevel = "NONE"; }
+
+  if (opt.logLevel == "") { }
+  else if (opt.logLevel == "TRACE")   { Logger::setLogLevel(LogType::TRACE); }
+  else if (opt.logLevel == "DEBUG")   { Logger::setLogLevel(LogType::DEBUG); }
+  else if (opt.logLevel == "INFO")    { Logger::setLogLevel(LogType::INFO); }
+  else if (opt.logLevel == "WARNING") { Logger::setLogLevel(LogType::WARNING); }
+  else if (opt.logLevel == "ERROR")   { Logger::setLogLevel(LogType::ERROR); }
+  else if (opt.logLevel == "NONE")    { Logger::setLogLevel(LogType::NONE); }
+  else {
+    std::cout << "ERROR: Invalid log level requested: " << opt.logLevel << std::endl;
+    return false;
+  }
+
+  if (opt.logLevel != "") {
+    std::cout << "Log level set to " << opt.logLevel << std::endl;
+  }
+
+  if (opt.logLineLimit >= 0) {
+    Logger::setLogLineLimit(opt.logLineLimit);
+    std::cout << "Log line limit set to " << opt.logLineLimit << std::endl;
+  }
+
+  if (opt.logFileLimit >= 0) {
+    Logger::setLogFileLimit(opt.logFileLimit);
+    std::cout << "Log file limit set to " << opt.logFileLimit << std::endl;
+  }
+
+  return true;
+}
+
+#endif // CLARGS_H

--- a/src/utils/finalizedblock.cpp
+++ b/src/utils/finalizedblock.cpp
@@ -10,7 +10,7 @@ See the LICENSE.txt file in the project root for more information.
 
 FinalizedBlock FinalizedBlock::fromBytes(const BytesArrView bytes, const uint64_t& requiredChainId) {
   try {
-    Logger::logToDebug(LogType::INFO, Log::finalizedBlock, __func__, "Deserializing block...");
+    Logger::logToDebug(LogType::TRACE, Log::finalizedBlock, __func__, "Deserializing block...");
     // Verify minimum size for a valid block
     if (bytes.size() < 217) throw std::runtime_error("Invalid block size - too short");
     // Parsing fixed-size fields
@@ -23,7 +23,7 @@ FinalizedBlock FinalizedBlock::fromBytes(const BytesArrView bytes, const uint64_
     uint64_t nHeight = Utils::bytesToUint64(bytes.subspan(201, 8));
     uint64_t txValidatorStart = Utils::bytesToUint64(bytes.subspan(209, 8));
 
-    Logger::logToDebug(LogType::INFO, Log::finalizedBlock, __func__, "Deserializing transactions...");
+    Logger::logToDebug(LogType::TRACE, Log::finalizedBlock, __func__, "Deserializing transactions...");
 
     std::vector<TxBlock> txs;
     std::vector<TxValidator> txValidators;

--- a/src/utils/finalizedblock.h
+++ b/src/utils/finalizedblock.h
@@ -79,7 +79,7 @@ class FinalizedBlock {
         validatorMerkleRoot_(std::move(validatorMerkleRoot)), txMerkleRoot_(std::move(txMerkleRoot)),
         timestamp_(timestamp), nHeight_(nHeight),
         txValidators_(std::move(txValidators)), txs_(std::move(txs)), hash_(std::move(hash)), size_(size)
-    {Logger::logToDebug(LogType::INFO, Log::finalizedBlock, __func__, "Finalized block moved");}
+    {Logger::logToDebug(LogType::TRACE, Log::finalizedBlock, __func__, "Finalized block moved");}
 
     /**
      * Move constructor.
@@ -98,7 +98,7 @@ class FinalizedBlock {
       txs_(std::move(block.txs_)),
       hash_(std::move(block.hash_)),
       size_(block.size_)
-    {Logger::logToDebug(LogType::INFO, Log::finalizedBlock, __func__, "Finalized block moved");}
+    {Logger::logToDebug(LogType::TRACE, Log::finalizedBlock, __func__, "Finalized block moved");}
 
     /**
      * Copy constructor.
@@ -117,7 +117,7 @@ class FinalizedBlock {
       txs_(block.txs_),
       hash_(block.hash_),
       size_(block.size_)
-    {Logger::logToDebug(LogType::INFO, Log::finalizedBlock, __func__, "Finalized block copied");}
+    {Logger::logToDebug(LogType::TRACE, Log::finalizedBlock, __func__, "Finalized block copied");}
 
 
     static FinalizedBlock fromBytes(const BytesArrView bytes, const uint64_t& requiredChainId);

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -15,7 +15,7 @@ See the LICENSE.txt file in the project root for more information.
 #include <future>
 
 /// Enum for the log message types.
-enum class LogType { DEBUG, INFO, WARNING, ERROR };
+enum class LogType { TRACE, DEBUG, INFO, WARNING, ERROR, NONE };
 
 /// Namespace with string prefixes for each blockchain module, for printing log/debug messages.
 namespace Log {
@@ -56,6 +56,8 @@ namespace Log {
   const std::string contractHost = "ContractHost";
   const std::string dumpWorker = "DumpWorker";
   const std::string dumpManager = "DumpManager";
+  const std::string logger = "Logger";
+  const std::string sdkTestSuite = "SDKTestSuite";
   ///@}
 }
 
@@ -111,7 +113,10 @@ class LogInfo {
 class Logger {
   private:
     /// Private constructor as it is a singleton.
-    Logger() : logFile_("debug.log", std::ios::out | std::ios::app) {
+    Logger() : activeLogFileName_("bdk.log") {
+      logLevel_ = LogType::NONE; // The logger component does not log anything by default
+      logLineLimit_ = 100000;
+      logFileLimit_ = 0; // No limit to the number of log files by default
       logThreadFuture_ = std::async(std::launch::async, &Logger::logger, this);
     }
     Logger(const Logger&) = delete;             ///< Make it non-copyable
@@ -120,6 +125,10 @@ class Logger {
     /// Get the instance.
     static Logger& getInstance() { static Logger instance; return instance; }
 
+    const std::string activeLogFileName_;   ///< Base name for log files
+    std::atomic<LogType> logLevel_;         ///< Current log level (doesn't log anything less than this).
+    std::atomic<int> logLineLimit_;         ///< Number of log lines until the log rotates.
+    std::atomic<int> logFileLimit_;         ///< Number of log files to keep before deleting older ones.
     std::ofstream logFile_;                 ///< The file stream.
     std::mutex logQueueMutex_;              ///< Mutex for protecting access to the log queue.
     std::condition_variable cv_;            ///< Conditional variable to wait for new tasks.
@@ -130,15 +139,58 @@ class Logger {
 
     /// Function for the future object.
     void logger() {
+      int logFileNum = -1;
+      int logLineCount = INT_MAX;
       while (true) {
-        std::unique_lock<std::mutex> lock(logQueueMutex_);
+        if (logLineCount > logLineLimit_) {
+          if (logFileNum >= 0) {
+            std::string archiveLogFileName = activeLogFileName_ + "." + std::to_string(logFileNum);
+            curTask_ = LogInfo(LogType::NONE, Log::logger, __func__,
+                              "Copying rotating log file " + activeLogFileName_ + " to " + archiveLogFileName);
+            logFileInternal();
+            logFile_.close();
+            if (logFileLimit_ != 1) { // If the limit is 1, then we keep only the active one
+              try {
+                std::filesystem::copy(activeLogFileName_, archiveLogFileName,
+                                      std::filesystem::copy_options::overwrite_existing);
+              } catch (const std::filesystem::filesystem_error& e) {
+                std::cout << "ERROR: Failed to copy rotating log file " << activeLogFileName_
+                          << " to " << archiveLogFileName << "(" << e.what() << ")" << std::endl;
+              }
+              // Handle log file limit (only guaranteed to work if you don't change the limit after boot)
+              if (logFileLimit_ > 0) {
+                int oldestLogFileNum = logFileNum - logFileLimit_ + 1;
+                if (oldestLogFileNum >= 0) {
+                  std::string oldLogFileName = activeLogFileName_ + "." + std::to_string(oldestLogFileNum);
+                  try {
+                    std::filesystem::remove(oldLogFileName);
+                  } catch (const std::filesystem::filesystem_error& e) {
+                    std::cout << "ERROR: Failed to remove old log file " << oldLogFileName
+                              << "(" << e.what() << ")" << std::endl;
+                  }
+                }
+              }
+            }
+          }
+          logLineCount = 0;
+          ++logFileNum;
+          logFile_.open(activeLogFileName_, std::ios::out | std::ios::trunc);
+          std::string nextArchiveLogFileName = activeLogFileName_ + "." + std::to_string(logFileNum);
+          curTask_ = LogInfo(LogType::NONE, Log::logger, __func__,
+                    "Starting rotating log file #" + std::to_string(logFileNum)
+                    + " (will later be archived to " + nextArchiveLogFileName + ")");
+          logFileInternal();
+        }
         // Wait until there's a task in the queue or stopWorker_ is true.
-        cv_.wait(lock, [this] { return !logQueue_.empty() || stopWorker_; });
-        if (stopWorker_) return;  // If stopWorker_ is true, return.
-        curTask_ = std::move(logQueue_.front());
-        logQueue_.pop();
-        lock.unlock();
+        {
+          std::unique_lock<std::mutex> lock(logQueueMutex_);
+          cv_.wait(lock, [this] { return !logQueue_.empty() || stopWorker_; });
+          if (stopWorker_) return;  // If stopWorker_ is true, return.
+          curTask_ = std::move(logQueue_.front());
+          logQueue_.pop();
+        }
         logFileInternal();
+        ++logLineCount;
       }
     };
 
@@ -149,10 +201,13 @@ class Logger {
     void logFileInternal() {
       std::string logType = "";
       switch (curTask_.getType()) {
+        case LogType::TRACE: logType = "TRACE"; break;
         case LogType::DEBUG: logType = "DEBUG"; break;
         case LogType::INFO: logType = "INFO"; break;
         case LogType::WARNING: logType = "WARNING"; break;
         case LogType::ERROR: logType = "ERROR"; break;
+        case LogType::NONE: logType = "NONE"; break;
+        default: logType = "INVALID_LOG_TYPE"; break;
       }
       this->logFile_ << "[" << getCurrentTimestamp() << " " << logType << "] "
         << curTask_.getLogSrc() << "::" << curTask_.getFunc()
@@ -169,13 +224,46 @@ class Logger {
     };
 
   public:
+
+    /**
+     * Set the log level.
+     * @param logLevel The log level.
+     */
+    static inline void setLogLevel(LogType logLevel) {
+      getInstance().logLevel_ = logLevel;
+    }
+
+    /**
+     * Get the log level.
+     * @return The current log level.
+     */
+    static inline LogType getLogLevel() {
+      return getInstance().logLevel_;
+    }
+
+    /**
+     * Set the log line limit for each rotating log file.
+     * @param logLineLimit Number of lines in bdk.log before it is archived and reset.
+     */
+    static inline void setLogLineLimit(int logLineLimit) {
+      getInstance().logLineLimit_ = logLineLimit;
+    }
+
+    /**
+     * Set the log file limit for each rotating log file.
+     * @param logLineLimit Maximum number of log files to keep (0 = no limit).
+     */
+    static inline void setLogFileLimit(int logFileLimit) {
+      getInstance().logFileLimit_ = logFileLimit;
+    }
+
     /**
      * Log debug data to the debug file.
      * @param infoToLog The data to log.
      */
     static inline void logToDebug(LogInfo&& infoToLog) noexcept {
-      // TODO: This is commented out because we are generating a large log file.
-      //getInstance().postLogTask(std::move(infoToLog));
+      if (infoToLog.getType() < getInstance().logLevel_) return;
+      getInstance().postLogTask(std::move(infoToLog));
     }
 
     /**
@@ -188,9 +276,9 @@ class Logger {
     static inline void logToDebug(
       LogType type, const std::string& logSrc, std::string&& func, std::string&& message
     ) noexcept {
-      // TODO: This is commented out because we are generating a large log file.
-      //auto log = LogInfo(type, logSrc, std::move(func), std::move(message));
-      //getInstance().postLogTask(std::move(log));
+      if (type < getInstance().logLevel_) return;
+      auto log = LogInfo(type, logSrc, std::move(func), std::move(message));
+      getInstance().postLogTask(std::move(log));
     }
 
     /// Destructor.

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -7,6 +7,8 @@ See the LICENSE.txt file in the project root for more information.
 
 #include "utils.h"
 
+#include <csignal>
+
 std::mutex log_lock;
 std::mutex debug_mutex;
 std::mutex cout_mutex;
@@ -811,5 +813,14 @@ json Utils::readConfigFile() {
   std::ifstream configFile("config.json");
   json config = json::parse(configFile);
   return config;
+}
+
+std::string Utils::getSignalName(int signum) {
+  std::string n;
+  if (signum == SIGINT) n = "SIGINT";
+  else if (signum == SIGHUP) n = "SIGHUP";
+  else n = "Unknown signal";
+  n += " (" + std::to_string(signum) + ")";
+  return n;
 }
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -785,10 +785,18 @@ namespace Utils {
 
   /**
    * Shorthand for obtaining a milliseconds-since-epoch uint64_t timestamp from std::chrono
+   * @return Milliseconds elapsed since epoch.
    */
   inline uint64_t getCurrentTimeMillisSinceEpoch() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
   }
+
+  /**
+   * Given an UNIX signal number, return the name followed by the number in parenthesis.
+   * @param signum The signal number.
+   * @return A string containing the signal name (or "Unknown signal") and number.
+   */
+  std::string getSignalName(int signum);
 };
 
 #endif  // UTILS_H

--- a/tests/blockchainwrapper.hpp
+++ b/tests/blockchainwrapper.hpp
@@ -255,4 +255,19 @@ bool testCheckTime(const char* file, int line, Func&& func, int timeLimitSeconds
 #define TEST_CHECK_TIME_VERBOSE(func, timeLimitSeconds) \
     testCheckTime(__FILE__, __LINE__, [&]() { return (func); }, timeLimitSeconds, true)
 
+/**
+ * Helper class for temporarily changing the log level in the scope of unit tests.
+ */
+class TempLogLevel {
+  LogType old_;
+public:
+  TempLogLevel(LogType tmp) {
+    old_ = Logger::getLogLevel();
+    Logger::setLogLevel(tmp);
+  }
+  ~TempLogLevel() {
+    Logger::setLogLevel(old_);
+  }
+};
+
 #endif // BLOCKCHAINWRAPPER_H

--- a/tests/core/dumpmanager.cpp
+++ b/tests/core/dumpmanager.cpp
@@ -48,8 +48,7 @@ namespace TDumpManager {
           auto block = createValidBlock(validatorPrivKeysState,
                                         blockchainWrapper.state,
                                         blockchainWrapper.storage);
-          REQUIRE(blockchainWrapper.state.validateNextBlock(block));
-          blockchainWrapper.state.processNextBlock(std::move(block));
+          REQUIRE(blockchainWrapper.state.tryProcessNextBlock(std::move(block)) == BlockValidationStatus::valid);
         }
         // stop the dump worker
         blockchainWrapper.state.dumpStopWorker();

--- a/tests/core/rdpos.cpp
+++ b/tests/core/rdpos.cpp
@@ -504,6 +504,8 @@ namespace TRdPoS {
   }
 
   TEST_CASE("rdPoS class with Network and rdPoSWorker Functionality, move 10 blocks forward", "[core][rdpos][net][heavy]") {
+    TempLogLevel tll(LogType::TRACE);
+
     PrivKey chainOwnerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
     Address chainOwnerAddress = Secp256k1::toAddress(Secp256k1::toUPub(chainOwnerPrivKey));
     // Initialize 8 different node instances, with different ports and DBs.

--- a/tests/core/state.cpp
+++ b/tests/core/state.cpp
@@ -102,8 +102,7 @@ namespace TState {
         // to save the state to the DB.
         // "0" is specifically used to say there is no state to load from.
         auto newBlock = createValidBlock(validatorPrivKeysState, blockchainWrapper.state, blockchainWrapper.storage);
-        REQUIRE(blockchainWrapper.state.validateNextBlock(newBlock));
-        blockchainWrapper.state.processNextBlock(std::move(newBlock));
+        REQUIRE(blockchainWrapper.state.tryProcessNextBlock(std::move(newBlock)) == BlockValidationStatus::valid);
         blockchainWrapper.state.saveToDB();
       }
       // Wait until destructors are called.
@@ -122,8 +121,7 @@ namespace TState {
         auto blockchainWrapper = initialize(validatorPrivKeysState, validatorPrivKeysState[0], 8080, true, testDumpPath + "/stateSimpleBlockTest");
 
         auto newBlock = createValidBlock(validatorPrivKeysState, blockchainWrapper.state, blockchainWrapper.storage);
-        REQUIRE(blockchainWrapper.state.validateNextBlock(newBlock));
-        blockchainWrapper.state.processNextBlock(std::move(newBlock));
+        REQUIRE(blockchainWrapper.state.tryProcessNextBlock(std::move(newBlock)) == BlockValidationStatus::valid);
         latestBlock = std::make_unique<FinalizedBlock>(*blockchainWrapper.storage.latest().get());
         blockchainWrapper.state.saveToDB();
       }
@@ -171,9 +169,7 @@ namespace TState {
         }
 
         auto newBestBlock = createValidBlock(validatorPrivKeysState, blockchainWrapper.state, blockchainWrapper.storage, std::move(transactions));
-        REQUIRE(blockchainWrapper.state.validateNextBlock(newBestBlock));
-
-        blockchainWrapper.state.processNextBlock(std::move(newBestBlock));
+        REQUIRE(blockchainWrapper.state.tryProcessNextBlock(std::move(newBestBlock)) == BlockValidationStatus::valid);
 
         for (const auto &[privkey, val]: randomAccounts) {
           auto me = Secp256k1::toAddress(Secp256k1::toUPub(privkey));
@@ -223,9 +219,7 @@ namespace TState {
         REQUIRE(txCopy.size() == 500);
 
         auto newBestBlock = createValidBlock(validatorPrivKeysState, blockchainWrapper.state, blockchainWrapper.storage, std::move(txCopy));
-        REQUIRE(blockchainWrapper.state.validateNextBlock(newBestBlock));
-
-        blockchainWrapper.state.processNextBlock(std::move(newBestBlock));
+        REQUIRE(blockchainWrapper.state.tryProcessNextBlock(std::move(newBestBlock)) == BlockValidationStatus::valid);
 
         for (const auto &[privkey, val]: randomAccounts) {
           auto me = Secp256k1::toAddress(Secp256k1::toUPub(privkey));
@@ -284,9 +278,7 @@ namespace TState {
         }
 
         auto newBestBlock = createValidBlock(validatorPrivKeysState, blockchainWrapper.state, blockchainWrapper.storage, std::move(txs));
-        REQUIRE(blockchainWrapper.state.validateNextBlock(newBestBlock));
-
-        blockchainWrapper.state.processNextBlock(std::move(newBestBlock));
+        REQUIRE(blockchainWrapper.state.tryProcessNextBlock(std::move(newBestBlock)) == BlockValidationStatus::valid);
 
         REQUIRE(blockchainWrapper.state.getMempool().size() == notOnBlock.size());
 
@@ -348,9 +340,7 @@ namespace TState {
 
           // Create the new block
           auto newBestBlock = createValidBlock(validatorPrivKeysState, blockchainWrapper.state, blockchainWrapper.storage, std::move(txs));
-          REQUIRE(blockchainWrapper.state.validateNextBlock(newBestBlock));
-
-          blockchainWrapper.state.processNextBlock(std::move(newBestBlock));
+          REQUIRE(blockchainWrapper.state.tryProcessNextBlock(std::move(newBestBlock)) == BlockValidationStatus::valid);
           for (const auto &[privkey, val]: randomAccounts) {
             auto me = Secp256k1::toAddress(Secp256k1::toUPub(privkey));
             REQUIRE(blockchainWrapper.state.getNativeBalance(me) == val.first);

--- a/tests/net/http/httpjsonrpc.cpp
+++ b/tests/net/http/httpjsonrpc.cpp
@@ -155,9 +155,7 @@ namespace THTTPJsonRPC{
 
       auto newBestBlock = createValidBlock(validatorPrivKeysHttpJsonRpc, blockchainWrapper.state, blockchainWrapper.storage, std::move(transactionsCopy));
 
-      REQUIRE(blockchainWrapper.state.validateNextBlock(newBestBlock));
-
-      blockchainWrapper.state.processNextBlock(FinalizedBlock(newBestBlock));
+      REQUIRE(blockchainWrapper.state.tryProcessNextBlock(std::move(newBestBlock)) == BlockValidationStatus::valid);
 
       blockchainWrapper.http.start();
       std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/tests/sdktestsuite.cpp
+++ b/tests/sdktestsuite.cpp
@@ -11,7 +11,97 @@ See the LICENSE.txt file in the project root for more information.
 #include "../../src/contract/templates/erc20.h"
 #include "../../src/contract/templates/simplecontract.h"
 #include "../../src/contract/templates/testThrowVars.h"
+#include "../../src/utils/clargs.h"
 #include <tuple>
+
+/**
+ * Custom logging listener for Catch2
+ */
+class LoggingListener : public Catch::EventListenerBase {
+public:
+  using EventListenerBase::EventListenerBase;
+
+  std::string testCaseName = "NONE";
+
+  // Called when a test run is starting
+  void testRunStarting(Catch::TestRunInfo const& testRunInfo) override {
+    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
+      "Starting test run: " + testRunInfo.name);
+  }
+
+  // Called when a test case is starting
+  void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
+    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
+      "Starting TEST_CASE: " + testInfo.name);
+    testCaseName = testInfo.name;
+  }
+
+  // Called when a section is starting
+  void sectionStarting(Catch::SectionInfo const& sectionInfo) override {
+    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
+      "[" + testCaseName + "]: Starting SECTION: " + sectionInfo.name);
+  }
+
+  void sectionEnded(Catch::SectionStats const& sectionStats) override {
+    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
+      "[" + testCaseName + "]: Finished SECTION: " + sectionStats.sectionInfo.name);
+  }
+
+  // Called when a test case has ended
+  void testCaseEnded(Catch::TestCaseStats const& testCaseStats) override {
+    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
+      "Finished TEST_CASE: " + testCaseStats.testInfo->name);
+    testCaseName = "NONE";
+  }
+
+  // Called when a test run has ended
+  void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
+      "Finished test run: " + std::to_string(testRunStats.totals.testCases.total())
+      + " test cases run.");
+  }
+};
+
+CATCH_REGISTER_LISTENER(LoggingListener)
+
+/**
+ * Custom main function for Catch2.
+ * We can define our own main() here because CMakeLists.txt is
+ * defining CATCH_AMALGAMATED_CUSTOM_MAIN.
+ */
+int main(int argc, char* argv[]) {
+  Utils::safePrintTest("bdkd-tests: Blockchain Development Kit unit test suite");
+  Utils::safePrintTest("Any arguments before -- are sent to Catch2");
+  Utils::safePrintTest("Any arguments after -- are sent to the BDK args parser");
+
+  std::vector<char*> bdkArgs;
+  std::vector<char*> catchArgs;
+  bdkArgs.push_back(argv[0]);
+  catchArgs.push_back(argv[0]);
+
+  bool bdkArgsStarted = false;
+  for (int i = 1; i < argc; ++i) {
+    if (strcmp(argv[i], "--") == 0) {
+      bdkArgsStarted = true;
+      continue;
+    }
+    if (bdkArgsStarted) {
+      bdkArgs.push_back(argv[i]);
+    } else {
+      catchArgs.push_back(argv[i]);
+    }
+  }
+
+  // Even if there are no BDK args supplied, run this to apply the default debug level we want
+  Utils::safePrintTest("Processing BDK args and defaults...");
+  ProcessOptions opt = parseCommandLineArgs(bdkArgs.size(), bdkArgs.data(), BDKTool::UNIT_TEST_SUITE);
+  if (opt.logLevel == "") opt.logLevel = "DEBUG";
+  if (!applyProcessOptions(opt)) return 1;
+
+  Utils::safePrintTest("Running Catch2...");
+  int result = Catch::Session().run(catchArgs.size(), catchArgs.data());
+  return result;
+}
 
 namespace TSDKTestSuite {
   TEST_CASE("SDK Test Suite", "[sdktestsuite]") {

--- a/tests/sdktestsuite.hpp
+++ b/tests/sdktestsuite.hpp
@@ -246,23 +246,24 @@ class SDKTestSuite {
                                                                   newBlocknHeight,
                                                                   blockSignerPrivKey);
         // After finalization, the block should be valid. If it is, process the next one.
-        if (!this->state_.validateNextBlock(finalizedBlock)) throw DynamicException(
-          "SDKTestSuite::advanceBlock: Block is not valid"
-        );
-        state_.processNextBlock(std::move(finalizedBlock));
+        BlockValidationStatus bvs = state_.tryProcessNextBlock(std::move(finalizedBlock));
+        if (bvs != BlockValidationStatus::valid) {
+          throw DynamicException("SDKTestSuite::advanceBlock: Block is not valid");
+        }
         return this->storage_.latest();
       } else {
-        auto finelizedBlock = FinalizedBlock::createNewValidBlock(std::move(txs),
+        //TODO/REVIEW: These branches are identical?
+        auto finalizedBlock = FinalizedBlock::createNewValidBlock(std::move(txs),
                                                                   std::move(txsValidator),
                                                                   newBlockPrevHash,
                                                                   newBlockTimestamp,
                                                                   newBlocknHeight,
                                                                   blockSignerPrivKey);
         // After finalization, the block should be valid. If it is, process the next one.
-        if (!this->state_.validateNextBlock(finelizedBlock)) throw DynamicException(
-          "SDKTestSuite::advanceBlock: Block is not valid"
-        );
-        state_.processNextBlock(std::move(finelizedBlock));
+        BlockValidationStatus bvs = state_.tryProcessNextBlock(std::move(finalizedBlock));
+        if (bvs != BlockValidationStatus::valid) {
+          throw DynamicException("SDKTestSuite::advanceBlock: Block is not valid");
+        }
         return this->storage_.latest();
       }
     }


### PR DESCRIPTION
This PR in a nutshell:

- Logging made more useful with log levels and rotating logs
- New main() for bdkd, bdkd-tests and bdkd-discovery
- Fixed signal handling / ^C in main threads, and associated shutdown routines
- Control behavior of the log file ("bdk.log") via command-line
- Bug fixes & misc improvements 

Details:

- Re-enabled logging with Logger::logToDebug()
- Logger now logs to bdk.log with support to rotating log files via a size limit (backs up to bdk.log.0, bdk.log.1, etc.) and a log file count limit
- Added command-line argument support to bdkd, bdkd-discovery and bdkd-tests, with support for custom arguments and custom defaults for each
  - --help / -h
  - --loglevel / -l: set the verbosity level of bdk.log to one of TRACE, DEBUG, INFO, WARNING, ERROR, NONE
  - --loglinelimit: set the maximum number of lines to be logged before the log file is rotated/archived
  - --logfilelimit: set the maximum number of log files (active + archived) that is kept
- Added custom main() to bdkd-tests, allowing us to e.g. configure the logging for the tests with command-line args (still able to pass arguments to Catch2 as well)
- Fixed signal handling (^C) & proper shutdown in bdkd & bdkd-discovery main thread
- Downgraded multiple logging messages to lower log types
- Fixed several redundant State::validateNextBlock() followed by State::processNextBlock() (using State::tryProcessNextBlock() instead, which runs block validation only once; also reduces logging)
- Fixed missing stopWorker() in DumpWorker::~DumpWorker
- Removed a handful of logging to "log.txt" and redirected them to the new Logger::logToDebug() ("bdk.log") as TRACE messages
- Added event listeners to Catch2, which log entering and leaving each TEST_CASE and SECTION as INFO log messages
- Added TempLogLevel helper class to the unit test suite to help changing the log level temporarily for a test or test scope
- Set temp log level for the last rdPoS test (failing) to TRACE