### PR TITLE
Revamp/improve logging & logging tools

### DIFF
--- a/src/bins/bdkd-discovery/main.cpp
+++ b/src/bins/bdkd-discovery/main.cpp
@@ -28,7 +28,7 @@ void signalHandler(int signum) {
 
 /// Executable with a discovery node for the given Options default chain.
 int main(int argc, char* argv[]) {
-  Utils::logToCout = true;
+  Log::logToCout = true;
   Utils::safePrint("bdkd-discovery: Blockchain Development Kit discovery node daemon");
   std::signal(SIGINT, signalHandler);
   std::signal(SIGHUP, signalHandler);
@@ -63,7 +63,7 @@ int main(int argc, char* argv[]) {
   Utils::safePrint("Main thread stopping due to interrupt signal [" + Utils::getSignalName(exitCode) + "], shutting down node...");
 
   // Shut down the node
-  Logger::logToDebug(LogType::INFO, "MAIN", "MAIN", "Received signal " + std::to_string(exitCode));
+  SLOGINFO("Received signal " + std::to_string(exitCode));
   Utils::safePrint("Main thread stopping node...");
   p2p->stopDiscovery();
   Utils::safePrint("Main thread shutting down...");

--- a/src/bins/bdkd/main.cpp
+++ b/src/bins/bdkd/main.cpp
@@ -30,7 +30,7 @@ void signalHandler(int signum) {
 }
 
 int main(int argc, char* argv[]) {
-  Utils::logToCout = true;
+  Log::logToCout = true;
   Utils::safePrint("bdkd: Blockchain Development Kit full node daemon");
   std::signal(SIGINT, signalHandler);
   std::signal(SIGHUP, signalHandler);
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
   Utils::safePrint("Main thread stopping due to interrupt signal [" + Utils::getSignalName(exitCode) + "], shutting down node...");
 
   // Shut down the node
-  Logger::logToDebug(LogType::INFO, "MAIN", "MAIN", "Received signal " + std::to_string(exitCode));
+  SLOGINFO("Received signal " + std::to_string(exitCode));
   Utils::safePrint("Main thread stopping node...");
   blockchain->stop();
   Utils::safePrint("Main thread shutting down...");

--- a/src/bins/faucet-api/main.cpp
+++ b/src/bins/faucet-api/main.cpp
@@ -11,7 +11,7 @@
 // The HTTP endpoint (for HTTP client) (IP:PORT)
 // The port for the server
 int main() {
-  Utils::logToCout = true;
+  Log::logToCout = true;
   std::vector<WorkerAccount> faucetWorkers;
   uint64_t chainId;
   std::pair<net::ip::address_v4, uint16_t> httpEndpoint;

--- a/src/bins/faucet-api/src/faucetmanager.cpp
+++ b/src/bins/faucet-api/src/faucetmanager.cpp
@@ -86,10 +86,7 @@ namespace Faucet {
         }
         // Update nonce
       } catch (std::exception& e) {
-        Utils::safePrint("Error while processing dripToAddress: " + std::string(e.what()));
-        Logger::logToDebug(LogType::ERROR, "FaucetManager", __func__,
-          std::string("Error while processing dripToAddress: ") + e.what()
-        );
+        LOGERRORP(std::string("Error while processing dripToAddress: ") + e.what());
       }
     }
     return true;

--- a/src/bins/faucet-api/src/httpserver.cpp
+++ b/src/bins/faucet-api/src/httpserver.cpp
@@ -20,14 +20,12 @@ namespace Faucet {
     std::vector<std::thread> v;
     v.reserve(4 - 1);
     for (int i = 4 - 1; i > 0; i--) v.emplace_back([&]{ this->ioc_.run(); });
-    Logger::logToDebug(LogType::INFO, Log::httpServer, __func__,
-      std::string("HTTP Server Started at port: ") + std::to_string(port_)
-    );
+    LOGINFO(std::string("HTTP Server Started at port: ") + std::to_string(port_));
     this->ioc_.run();
 
     // If we get here, it means we got a SIGINT or SIGTERM. Block until all the threads exit
     for (std::thread& t : v) t.join();
-    Logger::logToDebug(LogType::INFO, Log::httpServer, __func__, "HTTP Server Stopped");
+    LOGINFO("HTTP Server Stopped");
     return true;
   }
 

--- a/src/bins/faucet-api/src/jsonrpc/decoding.cpp
+++ b/src/bins/faucet-api/src/jsonrpc/decoding.cpp
@@ -27,9 +27,7 @@ namespace JsonRPC::Decoding {
 
       return true;
     } catch (std::exception& e) {
-      Logger::logToDebug(LogType::ERROR, Log::JsonRPCDecoding, __func__,
-        std::string("Error while checking json RPC spec: ") + e.what()
-      );
+      LOGERROR(std::string("Error while checking json RPC spec: ") + e.what());
       throw DynamicException("Error while checking json RPC spec: " + std::string(e.what()));
     }
   }
@@ -41,9 +39,7 @@ namespace JsonRPC::Decoding {
       if (it == methodsLookupTable.end()) return Methods::invalid;
       return it->second;
     } catch (std::exception& e) {
-      Logger::logToDebug(LogType::ERROR, Log::JsonRPCDecoding, __func__,
-        std::string("Error while getting method: ") + e.what()
-      );
+      LOGERROR(std::string("Error while getting method: ") + e.what());
       throw DynamicException("Error while checking json RPC spec: " + std::string(e.what()));
     }
   }
@@ -55,9 +51,7 @@ namespace JsonRPC::Decoding {
       if (!std::regex_match(address, addFilter)) throw DynamicException("Invalid address hex");
       faucet.dripToAddress(Address(Hex::toBytes(address)));
     } catch (std::exception& e) {
-      Logger::logToDebug(LogType::ERROR, Log::JsonRPCDecoding, __func__,
-        std::string("Error while decoding dripToAddress: ") + e.what()
-      );
+      LOGERROR(std::string("Error while decoding dripToAddress: ") + e.what());
       throw DynamicException("Error while decoding dripToAddress: " + std::string(e.what()));
     }
   }

--- a/src/contract/event.h
+++ b/src/contract/event.h
@@ -109,9 +109,7 @@ class Event {
       if (!anonymous) this->topics_.push_back(eventSignature);
       for (const auto& topic : topics) {
         if (this->topics_.size() >= 4) {
-          Logger::logToDebug(LogType::WARNING, Log::event, std::source_location::current().function_name(),
-            "Attention! Event " + name + " has more than 3 indexed parameters. Only the first 3 will be indexed."
-          );
+          LOGWARNING("Attention! Event " + name + " has more than 3 indexed parameters. Only the first 3 will be indexed.");
           break;
         }
         this->topics_.push_back(topic);

--- a/src/core/blockchain.h
+++ b/src/core/blockchain.h
@@ -20,13 +20,11 @@ See the LICENSE.txt file in the project root for more information.
 #include "../utils/options.h"
 #include "../utils/db.h"
 
-class Blockchain; // Forward declaration for Syncer.
-
 /**
  * Helper class that syncs the node with other nodes in the network.
  * Currently it's *single threaded*, meaning that it doesn't require mutexes.
  */
-class Syncer {
+class Syncer : public Log::LogicalLocationProvider {
   private:
     P2P::ManagerNormal& p2p_;  ///< Reference to the P2P networking engine.
     const Storage& storage_;   ///< Reference to the blockchain storage.
@@ -41,6 +39,8 @@ class Syncer {
      */
     explicit Syncer(P2P::ManagerNormal& p2p, const Storage& storage, State& state) :
       p2p_(p2p), storage_(storage), state_(state) {}
+
+    virtual std::string getLogicalLocation() const { return p2p_.getLogicalLocation(); } ///< Log instance from P2P
 
     /**
      * Synchronize this node to the latest known blocks among all connected peers at the time this method is called.
@@ -63,13 +63,13 @@ class Syncer {
  * Contains, and acts as the middleman of, every other part of the core and net protocols.
  * Those parts interact with one another by communicating through this class.
  */
-class Blockchain {
+class Blockchain : public Log::LogicalLocationProvider {
   private:
     Options options_;           ///< Options singleton.
-    const DB db_;                     ///< Database.
+    P2P::ManagerNormal p2p_;    ///< P2P connection manager. NOTE: must be initialized first due to getLogicalLocation()
+    const DB db_;               ///< Database.
     Storage storage_;           ///< Blockchain storage.
     State state_;               ///< Blockchain state.
-    P2P::ManagerNormal p2p_;    ///< P2P connection manager.
     HTTPServer http_;           ///< HTTP server.
     Syncer syncer_;             ///< Blockchain syncer.
     Consensus consensus_;       ///< Block and transaction processing.
@@ -81,6 +81,7 @@ class Blockchain {
      */
     explicit Blockchain(const std::string& blockchainPath);
     ~Blockchain() = default;  ///< Default destructor.
+    virtual std::string getLogicalLocation() const { return p2p_.getLogicalLocation(); } ///< Log instance from P2P
     void start(); ///< Start the blockchain. Initializes P2P, HTTP and Syncer, in this order.
     void stop();  ///< Stop/shutdown the blockchain. Stops Syncer, HTTP and P2P, in this order (reverse order of start()).
 

--- a/src/core/consensus.cpp
+++ b/src/core/consensus.cpp
@@ -9,7 +9,7 @@ See the LICENSE.txt file in the project root for more information.
 #include "blockchain.h"
 
 void Consensus::validatorLoop() {
-  Logger::logToDebug(LogType::INFO, Log::consensus, __func__, "Starting validator loop.");
+  LOGINFO("Starting validator loop.");
   Validator me(Secp256k1::toAddress(Secp256k1::toUPub(this->options_.getValidatorPrivKey())));
   while (!this->stop_) {
     std::shared_ptr<const FinalizedBlock> latestBlock = this->storage_.latest();
@@ -28,7 +28,7 @@ void Consensus::validatorLoop() {
     bool logged = false;
     while (latestBlock == this->storage_.latest() && !this->stop_) {
       if (!logged) {
-        Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Waiting for next block to be created.");
+        LOGDEBUG("Waiting for next block to be created.");
         logged = true;
       }
       // Wait for next block to be created.
@@ -41,15 +41,13 @@ void Consensus::doValidatorBlock() {
   // TODO: Improve this somehow.
   // Wait until we are ready to create the block
   auto start = std::chrono::high_resolution_clock::now();
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Block creator: waiting for txs");
+  LOGDEBUG("Block creator: waiting for txs");
   uint64_t validatorMempoolSize = 0;
   std::unique_ptr<uint64_t> lastLog = nullptr;
   while (validatorMempoolSize != this->state_.rdposGetMinValidators() * 2 && !this->stop_) {
     if (lastLog == nullptr || *lastLog != validatorMempoolSize) {
       lastLog = std::make_unique<uint64_t>(validatorMempoolSize);
-      Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__,
-        "Block creator has: " + std::to_string(validatorMempoolSize) + " transactions in mempool"
-      );
+      LOGDEBUG("Block creator has: " + std::to_string(validatorMempoolSize) + " transactions in mempool");
     }
     validatorMempoolSize = this->state_.rdposGetMempoolSize();
     // Try to get more transactions from other nodes within the network
@@ -61,7 +59,7 @@ void Consensus::doValidatorBlock() {
     }
     std::this_thread::sleep_for(std::chrono::microseconds(10));
   }
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Validator ready to create a block");
+  LOGDEBUG("Validator ready to create a block");
 
   // Wait until we have all required transactions to create the block.
   auto waitForTxs = std::chrono::high_resolution_clock::now();
@@ -69,14 +67,14 @@ void Consensus::doValidatorBlock() {
   while (this->state_.getMempoolSize() < 1) {
     if (!logged) {
       logged = true;
-      Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Waiting for at least one transaction in the mempool.");
+      LOGDEBUG("Waiting for at least one transaction in the mempool.");
     }
     if (this->stop_) return;
 
     // Try to get transactions from the network.
     auto connectedNodesList = this->p2p_.getSessionsIDs(P2P::NodeType::NORMAL_NODE);
     for (auto const& nodeId : connectedNodesList) {
-      Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Requesting txs...");
+      LOGDEBUG("Requesting txs...");
       if (this->stop_) break;
       auto txList = this->p2p_.requestTxs(nodeId);
       if (this->stop_) break;
@@ -91,7 +89,7 @@ void Consensus::doValidatorBlock() {
   auto creatingBlock = std::chrono::high_resolution_clock::now();
 
   // Create the block.
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Ordering transactions and creating block");
+  LOGDEBUG("Ordering transactions and creating block");
   if (this->stop_) return;
   auto mempool = this->state_.rdposGetMempool();
   auto randomList = this->state_.rdposGetRandomList();
@@ -138,28 +136,28 @@ void Consensus::doValidatorBlock() {
   auto timestamp = std::chrono::duration_cast<std::chrono::microseconds>(
     std::chrono::system_clock::now().time_since_epoch()
   ).count();
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Create a new valid block.");
+  LOGDEBUG("Create a new valid block.");
   auto block = FinalizedBlock::createNewValidBlock(std::move(chainTxs),
                                                    std::move(validatorTxs),
                                                    latestBlock->getHash(),
                                                    timestamp,
                                                    latestBlock->getNHeight() + 1,
                                                    this->options_.getValidatorPrivKey());
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Block created, validating.");
+  LOGDEBUG("Block created, validating.");
   Hash latestBlockHash = block.getHash();
   BlockValidationStatus bvs = state_.tryProcessNextBlock(std::move(block));
   if (bvs != BlockValidationStatus::valid) {
-    Logger::logToDebug(LogType::ERROR, Log::consensus, __func__, "Block is not valid!");
+    LOGERROR("Block is not valid!");
     throw DynamicException("Block is not valid!");
   }
   if (this->stop_) return;
   if (this->storage_.latest()->getHash() != latestBlockHash) {
-    Logger::logToDebug(LogType::ERROR, Log::consensus, __func__, "Block is not valid!");
+    LOGERROR("Block is not valid!");
     throw DynamicException("Block is not valid!");
   }
 
   // Broadcast the block through P2P
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Broadcasting block.");
+  LOGDEBUG("Broadcasting block.");
   if (this->stop_) return;
   this->p2p_.getBroadcaster().broadcastBlock(this->storage_.latest());
   auto end = std::chrono::high_resolution_clock::now();
@@ -167,8 +165,7 @@ void Consensus::doValidatorBlock() {
   long double timeToConsensus = std::chrono::duration_cast<std::chrono::milliseconds>(waitForTxs - start).count();
   long double timeToTxs = std::chrono::duration_cast<std::chrono::milliseconds>(creatingBlock - waitForTxs).count();
   long double timeToBlock = std::chrono::duration_cast<std::chrono::milliseconds>(end - creatingBlock).count();
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__,
-    "Block created in: " + std::to_string(duration) + "ms, " +
+  LOGDEBUG("Block created in: " + std::to_string(duration) + "ms, " +
     "Time to consensus: " + std::to_string(timeToConsensus) + "ms, " +
     "Time to txs: " + std::to_string(timeToTxs) + "ms, " +
     "Time to block: " + std::to_string(timeToBlock) + "ms"
@@ -178,7 +175,7 @@ void Consensus::doValidatorBlock() {
 void Consensus::doValidatorTx(const uint64_t& nHeight, const Validator& me) {
   Hash randomness = Hash::random();
   Hash randomHash = Utils::sha3(randomness.get());
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Creating random Hash transaction");
+  LOGDEBUG("Creating random Hash transaction");
   Bytes randomHashBytes = Hex::toBytes("0xcfffe746");
   randomHashBytes.insert(randomHashBytes.end(), randomHash.get().begin(), randomHash.get().end());
   TxValidator randomHashTx(
@@ -203,25 +200,23 @@ void Consensus::doValidatorTx(const uint64_t& nHeight, const Validator& me) {
   BytesArrView randomHashTxView(randomHashTx.getData());
   BytesArrView randomSeedTxView(seedTx.getData());
   if (Utils::sha3(randomSeedTxView.subspan(4)) != randomHashTxView.subspan(4)) {
-    Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "RandomHash transaction is not valid!!!");
+    LOGDEBUG("RandomHash transaction is not valid!!!");
     return;
   }
 
   // Append to mempool and broadcast the transaction across all nodes.
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Broadcasting randomHash transaction");
+  LOGDEBUG("Broadcasting randomHash transaction");
   this->state_.rdposAddValidatorTx(randomHashTx);
   this->p2p_.getBroadcaster().broadcastTxValidator(randomHashTx);
 
   // Wait until we received all randomHash transactions to broadcast the randomness transaction
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Waiting for randomHash transactions to be broadcasted");
+  LOGDEBUG("Waiting for randomHash transactions to be broadcasted");
   uint64_t validatorMempoolSize = 0;
   std::unique_ptr<uint64_t> lastLog = nullptr;
   while (validatorMempoolSize < this->state_.rdposGetMinValidators() && !this->stop_) {
     if (lastLog == nullptr || *lastLog != validatorMempoolSize) {
       lastLog = std::make_unique<uint64_t>(validatorMempoolSize);
-      Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__,
-        "Validator has: " + std::to_string(validatorMempoolSize) + " transactions in mempool"
-      );
+      LOGDEBUG("Validator has: " + std::to_string(validatorMempoolSize) + " transactions in mempool");
     }
     validatorMempoolSize = this->state_.rdposGetMempoolSize();
     // Try to get more transactions from other nodes within the network
@@ -234,7 +229,7 @@ void Consensus::doValidatorTx(const uint64_t& nHeight, const Validator& me) {
     std::this_thread::sleep_for(std::chrono::microseconds(10));
   }
 
-  Logger::logToDebug(LogType::DEBUG, Log::consensus, __func__, "Broadcasting random transaction");
+  LOGDEBUG("Broadcasting random transaction");
   // Append and broadcast the randomness transaction.
   this->state_.addValidatorTx(seedTx);
   this->p2p_.getBroadcaster().broadcastTxValidator(seedTx);

--- a/src/core/consensus.h
+++ b/src/core/consensus.h
@@ -22,7 +22,7 @@ class Blockchain; // Forward declaration.
 // TODO: tests for Consensus (if necessary)
 
 /// Class responsible for processing blocks and transactions.
-class Consensus {
+class Consensus : public Log::LogicalLocationProvider {
   private:
     State& state_; ///< Reference to the State object.
     P2P::ManagerNormal& p2p_; ///< Reference to the P2P connection manager.
@@ -58,6 +58,8 @@ class Consensus {
      */
     explicit Consensus(State& state, P2P::ManagerNormal& p2p, const Storage& storage, const Options& options) :
       state_(state), p2p_(p2p), storage_(storage), options_(options) {}
+
+    virtual std::string getLogicalLocation() const { return p2p_.getLogicalLocation(); } ///< Log instance from P2P
 
     /**
      * Entry function for the worker thread (runs the workerLoop() function).

--- a/src/core/dump.cpp
+++ b/src/core/dump.cpp
@@ -48,10 +48,7 @@ std::pair<std::vector<DBBatch>, uint64_t> DumpManager::dumpState() const
     // or state changes are happening)
     blockHeight = storage_.latest()->getNHeight();
     // Emplace DBBatch operations
-    Logger::logToDebug(LogType::DEBUG,
-                       Log::dumpManager,
-                       __func__,
-                       "Emplace DBBatch operations");
+    LOGDEBUG("Emplace DBBatch operations");
 
     const auto nThreads = std::thread::hardware_concurrency();
     auto requiredOffset = this->dumpables_.size() / nThreads;
@@ -105,13 +102,13 @@ DumpWorker::DumpWorker(const Options& options,
     storage_(storage),
     dumpManager_(dumpManager)
 {
-  Logger::logToDebug(LogType::INFO, Log::dumpWorker, __func__, "DumpWorker Started.");
+  LOGINFO("DumpWorker Started.");
 }
 
 DumpWorker::~DumpWorker()
 {
   stopWorker();
-  Logger::logToDebug(LogType::INFO, Log::dumpWorker, __func__, "DumpWorker Stopped.");
+  LOGINFO("DumpWorker Stopped.");
 }
 
 bool DumpWorker::workerLoop()
@@ -119,10 +116,7 @@ bool DumpWorker::workerLoop()
   uint64_t latestBlock = this->storage_.currentChainSize();
   while (!this->stopWorker_) {
     if (latestBlock + this->options_.getStateDumpTrigger() < this->storage_.currentChainSize()) {
-      Logger::logToDebug(LogType::DEBUG,
-                         Log::dumpWorker,
-                         __func__,
-                         "Current size >= 100");
+      LOGDEBUG("Current size >= 100");
       dumpManager_.dumpToDB();
       latestBlock = this->storage_.currentChainSize();
     }

--- a/src/core/dump.h
+++ b/src/core/dump.h
@@ -37,7 +37,7 @@ class EventManager;
  * Dumpable management.
  * Used to store dumpable objects in memory.
  */
-class DumpManager {
+class DumpManager : public Log::LogicalLocationProvider {
 private:
   /// Reference to the options object
   const Options& options_;
@@ -67,6 +67,8 @@ public:
    * @param db Pointer to state database.
    */
   DumpManager(const Storage& storage, const Options& options, EventManager& eventManager, std::shared_mutex& stateMutex);
+
+  virtual std::string getLogicalLocation() const { return storage_.getLogicalLocation(); } ///< Log instance from Storage
 
   /**
    * Function that will register dumpable objects.
@@ -126,7 +128,7 @@ public:
   }
 };
 
-class DumpWorker {
+class DumpWorker : public Log::LogicalLocationProvider {
 private:
   /// Reference to the options object
   const Options& options_;
@@ -158,6 +160,8 @@ public:
    * Automatically stops the worker thread if it's still running.
    */
   ~DumpWorker();
+
+  virtual std::string getLogicalLocation() const { return storage_.getLogicalLocation(); } ///< Log instance from Storage
 
   ///< Start `workerFuture_` and `workerLoop()`.
   void startWorker();

--- a/src/core/rdpos.cpp
+++ b/src/core/rdpos.cpp
@@ -26,7 +26,7 @@ rdPoS::rdPoS(const DB& db,
     randomGen_(Hash()), minValidators_(options.getMinValidators())
 {
   // Initialize blockchain.
-  Logger::logToDebug(LogType::INFO, Log::rdPoS, __func__, "Initializing rdPoS.");
+  LOGINFO("Initializing rdPoS.");
   /**
    * Load information from DB, stored as following:
    * DBPrefix::rdPoS -> rdPoS mapping (addresses)
@@ -36,12 +36,12 @@ rdPoS::rdPoS(const DB& db,
   auto validatorsDb = db.getBatch(DBPrefix::rdPoS);
   if (validatorsDb.empty()) {
     // No rdPoS in DB, this should have been initialized by Storage.
-    Logger::logToDebug(LogType::INFO, Log::rdPoS, __func__, "No rdPoS in DB, initializing chain with Options.");
+    LOGINFO("No rdPoS in DB, initializing chain with Options.");
     for (const auto& address : this->options_.getGenesisValidators()) {
       this->validators_.insert(Validator(address));
     }
   } else {
-    Logger::logToDebug(LogType::INFO, Log::rdPoS, __func__, "Found " + std::to_string(validatorsDb.size()) + " rdPoS in DB");
+    LOGINFO("Found " + std::to_string(validatorsDb.size()) + " rdPoS in DB");
     // TODO: check if no index is missing from DB.
     for (const auto& validator : validatorsDb) {
       this->validators_.insert(Validator(Address(validator.value)));
@@ -63,8 +63,7 @@ bool rdPoS::validateBlock(const FinalizedBlock& block) const {
   auto latestBlock = this->storage_.latest();
 
   if (Secp256k1::toAddress(block.getValidatorPubKey()) != randomList_[0]) {
-    Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-      "Block signature does not match randomList[0]. latest nHeight: "
+    LOGERROR("Block signature does not match randomList[0]. latest nHeight: "
       + std::to_string(latestBlock->getNHeight())
       + " Block nHeight: " + std::to_string(block.getNHeight())
     );
@@ -72,8 +71,7 @@ bool rdPoS::validateBlock(const FinalizedBlock& block) const {
   }
 
   if (block.getTxValidators().size() != this->minValidators_ * 2) {
-    Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-      "Block contains invalid number of TxValidator transactions. latest nHeight: "
+    LOGERROR("Block contains invalid number of TxValidator transactions. latest nHeight: "
       + std::to_string(latestBlock->getNHeight())
       + " Block nHeight: " + std::to_string(block.getNHeight())
     );
@@ -83,8 +81,7 @@ bool rdPoS::validateBlock(const FinalizedBlock& block) const {
   // Check if all transactions are of the same block height
   for (const auto& tx : block.getTxValidators()) {
     if (tx.getNHeight() != block.getNHeight()) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        "TxValidator transaction is not of the same block height. tx nHeight: "
+      LOGERROR("TxValidator transaction is not of the same block height. tx nHeight: "
         + std::to_string(tx.getNHeight())
         + " Block nHeight: " + std::to_string(block.getNHeight()));
       return false;
@@ -103,16 +100,14 @@ bool rdPoS::validateBlock(const FinalizedBlock& block) const {
   std::unordered_map<TxValidator,TxValidator, SafeHash> txHashToSeedMap; // Tx randomHash -> Tx random
   for (uint64_t i = 0; i < this->minValidators_; i++) {
     if (Validator(block.getTxValidators()[i].getFrom()) != randomList_[i+1]) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        "TxValidator randomHash " + std::to_string(i) + " is not ordered correctly."
+      LOGERROR("TxValidator randomHash " + std::to_string(i) + " is not ordered correctly."
         + "Expected: " + randomList_[i+1].hex().get()
         + " Got: " + block.getTxValidators()[i].getFrom().hex().get()
       );
       return false;
     }
     if (Validator(block.getTxValidators()[i + this->minValidators_].getFrom()) != randomList_[i+1]) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        "TxValidator random " + std::to_string(i) + " is not ordered correctly."
+      LOGERROR("TxValidator random " + std::to_string(i) + " is not ordered correctly."
         + "Expected: " + randomList_[i+1].hex().get()
         + " Got: " + block.getTxValidators()[i].getFrom().hex().get()
       );
@@ -122,7 +117,7 @@ bool rdPoS::validateBlock(const FinalizedBlock& block) const {
   }
 
   if (txHashToSeedMap.size() != this->minValidators_) {
-    Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__, "txHashToSeedMap doesn't match minValidator size.");
+    LOGERROR("txHashToSeedMap doesn't match minValidator size.");
     return false;
   }
 
@@ -132,37 +127,28 @@ bool rdPoS::validateBlock(const FinalizedBlock& block) const {
     TxValidatorFunction seedTxFunction = rdPoS::getTxValidatorFunction(seedTx);
     // Check if hash tx is invalid by itself.
     if (hashTxFunction == TxValidatorFunction::INVALID) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        std::string("TxValidator ") + hashTx.hash().hex().get()  + " is invalid."
-      );
+      LOGERROR(std::string("TxValidator ") + hashTx.hash().hex().get()  + " is invalid.");
       return false;
     }
     if (seedTxFunction == TxValidatorFunction::INVALID) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        std::string("TxValidator ") + seedTx.hash().hex().get()  + " is invalid."
-      );
+      LOGERROR(std::string("TxValidator ") + seedTx.hash().hex().get()  + " is invalid.");
       return false;
     }
     // Check if senders match.
     if (hashTx.getFrom() != seedTx.getFrom()) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        std::string("TxValidator sender ") + seedTx.hash().hex().get()
+      LOGERROR(std::string("TxValidator sender ") + seedTx.hash().hex().get()
         + " does not match TxValidator sender " + hashTx.hash().hex().get()
       );
       return false;
     }
     // Check if the left sided transaction is a randomHash transaction.
     if (hashTxFunction != TxValidatorFunction::RANDOMHASH) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        std::string("TxValidator ") + hashTx.hash().hex().get() + " is not a randomHash transaction."
-      );
+      LOGERROR(std::string("TxValidator ") + hashTx.hash().hex().get() + " is not a randomHash transaction.");
       return false;
     }
     // Check if the right sided transaction is a random transaction.
     if (seedTxFunction != TxValidatorFunction::RANDOMSEED) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        std::string("TxValidator ") + seedTx.hash().hex().get() + " is not a random transaction."
-      );
+      LOGERROR(std::string("TxValidator ") + seedTx.hash().hex().get() + " is not a random transaction.");
       return false;
     }
     // Check if the randomHash transaction matches the random transaction.
@@ -173,22 +159,17 @@ bool rdPoS::validateBlock(const FinalizedBlock& block) const {
 
     // Size sanity check, should be 32 bytes.
     if (hash.size() != 32) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        std::string("TxValidator ") + hashTx.hash().hex().get() + " (hash) is not 32 bytes."
-      );
+      LOGERROR(std::string("TxValidator ") + hashTx.hash().hex().get() + " (hash) is not 32 bytes.");
       return false;
     }
 
     if (random.size() != 32) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        std::string("TxValidator ") + seedTx.hash().hex().get() + " (random) is not 32 bytes."
-      );
+      LOGERROR(std::string("TxValidator ") + seedTx.hash().hex().get() + " (random) is not 32 bytes.");
       return false;
     }
 
     if (Utils::sha3(random) != hash) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-        std::string("TxValidator ") + seedTx.hash().hex().get()
+      LOGERROR(std::string("TxValidator ") + seedTx.hash().hex().get()
         + " does not match TxValidator " + hashTx.hash().hex().get() + " randomness"
       );
       return false;
@@ -208,13 +189,12 @@ Hash rdPoS::processBlock(const FinalizedBlock& block) {
 
 TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
   if (this->validatorMempool_.contains(tx.hash())) {
-    Logger::logToDebug(LogType::TRACE, Log::rdPoS, __func__, "TxValidator already exists in mempool.");
+    LOGTRACE("TxValidator already exists in mempool.");
     return TxStatus::ValidExisting;
   }
 
   if (tx.getNHeight() != this->storage_.latest()->getNHeight() + 1) {
-    Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-      "TxValidator is not for the next block. Expected: "
+    LOGERROR("TxValidator is not for the next block. Expected: "
       + std::to_string(this->storage_.latest()->getNHeight() + 1)
       + " Got: " + std::to_string(tx.getNHeight())
     );
@@ -230,9 +210,7 @@ TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
     }
   }
   if (!participates) {
-    Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__,
-      "TxValidator sender is not a validator or is not participating in this rdPoS round."
-    );
+    LOGERROR("TxValidator sender is not a validator or is not participating in this rdPoS round.");
     return TxStatus::InvalidUnexpected;
   }
 
@@ -249,7 +227,7 @@ TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
 
   if (txs.size() == 1) { // We already have one transaction from this sender, check if it is the same function.
     if (txs[0].getFunctor() == tx.getFunctor()) {
-      Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__, "TxValidator sender already has a transaction for this function.");
+      LOGERROR("TxValidator sender already has a transaction for this function.");
       return TxStatus::InvalidRedundant;
     }
     this->validatorMempool_.emplace(tx.hash(), tx);
@@ -257,7 +235,7 @@ TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
   }
 
   // We already have two transactions from this sender, it is the max we can have per validator.
-  Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__, "TxValidator sender already has two transactions.");
+  LOGERROR("TxValidator sender already has two transactions.");
   return TxStatus::InvalidRedundant;
 }
 
@@ -277,7 +255,7 @@ rdPoS::TxValidatorFunction rdPoS::getTxValidatorFunction(const TxValidator &tx) 
   constexpr Functor randomHashHash(3489654598);
   constexpr Functor randomSeedHash(1875223254);
   if (tx.getData().size() != 36) {
-    Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__, "TxValidator data size is not 36 bytes.");
+    SLOGERROR("TxValidator data size is not 36 bytes.");
     // Both RandomHash and RandomSeed are 32 bytes, so if the data size is not 36 bytes, it is invalid.
     return TxValidatorFunction::INVALID;
   }
@@ -287,7 +265,7 @@ rdPoS::TxValidatorFunction rdPoS::getTxValidatorFunction(const TxValidator &tx) 
   } else if (functionABI == randomSeedHash) {
     return TxValidatorFunction::RANDOMSEED;
   } else {
-    Logger::logToDebug(LogType::ERROR, Log::rdPoS, __func__, "TxValidator function ABI is not recognized: " + std::to_string(functionABI.value) + " tx Data: " + Hex::fromBytes(tx.getData()).get());
+    SLOGERROR("TxValidator function ABI is not recognized: " + std::to_string(functionABI.value) + " tx Data: " + Hex::fromBytes(tx.getData()).get());
     return TxValidatorFunction::INVALID;
   }
 }
@@ -295,10 +273,7 @@ rdPoS::TxValidatorFunction rdPoS::getTxValidatorFunction(const TxValidator &tx) 
 DBBatch rdPoS::dump() const
 {
   DBBatch dbBatch;
-  Logger::logToDebug(LogType::DEBUG,
-                     Log::rdPoS,
-                     __func__,
-                     "Create batch operations.");
+  LOGDEBUG("Create batch operations.");
   // index
   uint64_t i = 0;
   // add batch operations

--- a/src/core/rdpos.h
+++ b/src/core/rdpos.h
@@ -60,7 +60,7 @@ class Validator : public Address {
 };
 
 /// Abstraction of the %rdPoS (Random Deterministic Proof of Stake) consensus algorithm.
-class rdPoS : public BaseContract {
+class rdPoS : public BaseContract, public Log::LogicalLocationProvider {
   private:
     const Options& options_;  ///< Reference to the options singleton.
     const Storage& storage_;  ///< Reference to the blockchain's storage.
@@ -94,6 +94,8 @@ class rdPoS : public BaseContract {
     rdPoS(const DB& db, DumpManager& manager, const Storage& storage, P2P::ManagerNormal& p2p, const Options& options, State& state);
 
     ~rdPoS() override;  ///< Destructor.
+
+    virtual std::string getLogicalLocation() const { return p2p_.getLogicalLocation(); } ///< Log instance from P2P
 
     ///@{
     /** Getter. */

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -24,7 +24,7 @@ See the LICENSE.txt file in the project root for more information.
 enum BlockValidationStatus { valid, invalidWrongHeight, invalidErroneous };
 
 /// Abstraction of the blockchain's current state at the current block.
-class State : Dumpable {
+class State : Dumpable, public Log::LogicalLocationProvider {
   private:
     mutable std::shared_mutex stateMutex_;  ///< Mutex for managing read/write access to the state object.
     evmc_vm* vm_;  ///< Pointer to the EVMC VM.
@@ -88,6 +88,8 @@ class State : Dumpable {
     State(const DB& db, Storage& storage, P2P::ManagerNormal& p2pManager, const uint64_t& snapshotHeight, const Options& options);
 
     ~State(); ///< Destructor.
+
+    virtual std::string getLogicalLocation() const { return p2pManager_.getLogicalLocation(); } ///< Log instance from P2P
 
     // ======================================================================
     // RDPOS WRAPPER FUNCTIONS

--- a/src/core/storage.cpp
+++ b/src/core/storage.cpp
@@ -7,18 +7,19 @@ See the LICENSE.txt file in the project root for more information.
 
 #include "storage.h"
 
-Storage::Storage(const Options& options)
-  : db_(options.getRootPath() + "/blocksDb/"),
+Storage::Storage(const std::string& instanceIdStr, const Options& options)
+  : instanceIdStr_(instanceIdStr),
+    db_(options.getRootPath() + "/blocksDb/"),
     options_(options),
     slThreads_(0)
 {
-  Logger::logToDebug(LogType::INFO, Log::storage, __func__, "Loading blockchain from DB");
+  LOGINFO("Loading blockchain from DB");
 
   // Initialize the blockchain if latest block doesn't exist.
   initializeBlockchain();
 
   // Get the latest block from the database
-  Logger::logToDebug(LogType::INFO, Log::storage, __func__, "Loading latest block");
+  LOGINFO("Loading latest block");
   auto blockBytes = this->db_.get(Utils::stringToBytes("latest"), DBPrefix::blocks);
   FinalizedBlock latest = FinalizedBlock::fromBytes(blockBytes, this->options_.getChainID());
   uint64_t depth = latest.getNHeight();
@@ -26,12 +27,12 @@ Storage::Storage(const Options& options)
   std::unique_lock<std::shared_mutex> lock(this->chainLock_);
 
   // Parse block mappings (hash -> height / height -> hash) from DB
-  Logger::logToDebug(LogType::INFO, Log::storage, __func__, "Parsing block mappings");
+  LOGINFO("Parsing block mappings");
   std::vector<DBEntry> maps = this->db_.getBatch(DBPrefix::blockHeightMaps);
   for (DBEntry& map : maps) {
     // TODO: Check if a block is missing.
     // Might be interesting to change DB::getBatch to return a map instead of a vector
-    Logger::logToDebug(LogType::DEBUG, Log::storage, __func__, std::string(": ")
+    LOGDEBUG(std::string(": ")
       + std::to_string(Utils::bytesToUint64(map.key))
       + std::string(", hash ") + Hash(map.value).hex().get()
     );
@@ -40,9 +41,9 @@ Storage::Storage(const Options& options)
   }
 
   // Append up to 500 most recent blocks from DB to chain
-  Logger::logToDebug(LogType::INFO, Log::storage, __func__, "Appending recent blocks");
+  LOGINFO("Appending recent blocks");
   for (uint64_t i = 0; i <= 500 && i <= depth; i++) {
-    Logger::logToDebug(LogType::DEBUG, Log::storage, __func__, std::string("Height: ")
+    LOGDEBUG(std::string("Height: ")
       + std::to_string(depth - i)
       + ", Hash: "
       + this->blockHashByHeight_[depth - i].hex().get()
@@ -50,7 +51,7 @@ Storage::Storage(const Options& options)
     FinalizedBlock finalBlock = FinalizedBlock::fromBytes(this->db_.get(this->blockHashByHeight_[depth - i].get(), DBPrefix::blocks), this->options_.getChainID());
     this->pushFrontInternal(std::move(finalBlock));
   }
-  Logger::logToDebug(LogType::INFO, Log::storage, __func__, "Blockchain successfully loaded");
+  LOGINFO("Blockchain successfully loaded");
 }
 
 Storage::~Storage() {
@@ -126,16 +127,14 @@ void Storage::initializeBlockchain() {
     this->db_.put(std::string("latest"), genesis.serializeBlock(), DBPrefix::blocks);
     this->db_.put(Utils::uint64ToBytes(genesis.getNHeight()), genesis.getHash().get(), DBPrefix::blockHeightMaps);
     this->db_.put(genesis.getHash().get(), genesis.serializeBlock(), DBPrefix::blocks);
-    Logger::logToDebug(LogType::INFO, Log::storage, __func__,
-      std::string("Created genesis block: ") + Hex::fromBytes(genesis.getHash().get()).get()
-    );
+    LOGINFO(std::string("Created genesis block: ") + Hex::fromBytes(genesis.getHash().get()).get());
   }
   // Sanity check for genesis block. (check if genesis in DB matches genesis in Options)
   const auto genesis = this->options_.getGenesisBlock();
   const auto genesisInDBHash = Hash(this->db_.get(Utils::uint64ToBytes(0), DBPrefix::blockHeightMaps));
   const auto genesisInDB = FinalizedBlock::fromBytes(this->db_.get(genesisInDBHash, DBPrefix::blocks), this->options_.getChainID());
   if (genesis != genesisInDB) {
-    Logger::logToDebug(LogType::ERROR, Log::storage, __func__, "Sanity Check! Genesis block in DB does not match genesis block in Options");
+    LOGERROR("Sanity Check! Genesis block in DB does not match genesis block in Options");
     throw DynamicException("Sanity Check! Genesis block in DB does not match genesis block in Options");
   }
 }
@@ -340,7 +339,7 @@ std::shared_ptr<const FinalizedBlock> Storage::getBlock(const uint64_t& height) 
   std::shared_lock<std::shared_mutex> lockCache(this->cacheLock_);
   StorageStatus blockStatus = this->blockExistsInternal(height);
   if (blockStatus == StorageStatus::NotFound) return nullptr;
-  Logger::logToDebug(LogType::TRACE, Log::storage, __func__, "height: " + std::to_string(height));
+  LOGTRACE("height: " + std::to_string(height));
   switch (blockStatus) {
     case StorageStatus::NotFound: {
       return nullptr;

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -25,11 +25,12 @@ enum StorageStatus { NotFound, OnChain, OnCache, OnDB };
  * Used to store blocks in memory and on disk, and helps the State process
  * new blocks, transactions and RPC queries.
  */
-class Storage {
+class Storage : public Log::LogicalLocationProvider {
   // TODO: possibly replace `std::shared_ptr<const Block>` with a better solution.
 private:
   DB db_;  ///< Database object that contains all the blockchain blocks
   const Options& options_;  ///< Reference to the options singleton.
+  const std::string instanceIdStr_; ///< Identifier for logging
   /**
    * Recent blockchain history, up to the 1000 most recent blocks or 1M transactions, whichever comes first.
    * This limit is required because it would be too expensive to keep every single transaction in memory
@@ -134,11 +135,12 @@ public:
   /**
    * Constructor. Automatically loads the chain from the database
    * and starts the periodic save thread.
-   * @param db Reference to the database.
+   * @param instanceIdStr Instance ID string to use for logging.
    * @param options Reference to the options singleton.
    */
-  Storage(const Options& options);
+  Storage(const std::string& instanceIdStr, const Options& options);
   ~Storage(); ///< Destructor. Automatically saves the chain to the database.
+  virtual std::string getLogicalLocation() const { return instanceIdStr_; } ///< Log instance (provided in ctor)
   void pushBack(FinalizedBlock block); ///< Wrapper for `pushBackInternal()`. Use this as it properly locks `chainLock_`.
   void pushFront(FinalizedBlock block);  ///< Wrapper for `pushFrontInternal()`. Use this as it properly locks `chainLock_`.
   void popBack(); ///< Remove a block from the end of the chain.

--- a/src/net/http/httpserver.h
+++ b/src/net/http/httpserver.h
@@ -12,7 +12,7 @@ See the LICENSE.txt file in the project root for more information.
 #include "httplistener.h"
 
 /// Abstraction of an HTTP server.
-class HTTPServer {
+class HTTPServer : public Log::LogicalLocationProvider {
   private:
     /// Reference pointer to the blockchain's state.
     State& state_;
@@ -54,6 +54,8 @@ class HTTPServer {
       P2P::ManagerNormal& p2p, const Options& options
     ) : state_(state), storage_(storage), p2p_(p2p), options_(options), port_(options.getHttpPort())
     {}
+
+    std::string getLogicalLocation() const; ///< Get log location from the P2P engine
 
     /**
      * Destructor.

--- a/src/net/p2p/client.cpp
+++ b/src/net/p2p/client.cpp
@@ -9,6 +9,9 @@ See the LICENSE.txt file in the project root for more information.
 #include "managerbase.h"
 
 namespace P2P {
+
+  std::string ClientFactory::getLogicalLocation() const { return manager_.getLogicalLocation(); }
+
   void ClientFactory::createClientSession(const boost::asio::ip::address &address, const unsigned short &port) {
     tcp::socket socket(io_context_);
     auto session = std::make_shared<Session>(std::move(socket), ConnectionType::OUTBOUND, manager_, address, port);
@@ -16,9 +19,7 @@ namespace P2P {
   }
 
   bool ClientFactory::run() {
-    Logger::logToDebug(LogType::INFO, Log::P2PClientFactory, __func__,
-                      "Starting P2P Client Factory "
-    );
+    LOGINFO("Starting P2P Client Factory ");
 
     // Restart is needed to .run() the ioc again, otherwise it returns instantly.
     io_context_.restart();
@@ -34,7 +35,7 @@ namespace P2P {
 
   bool ClientFactory::start() {
     if (this->executor_.valid()) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PClientFactory, __func__, "P2P Client Factory already started.");
+      LOGERROR("P2P Client Factory already started.");
       return false;
     }
     this->executor_ = std::async(std::launch::async, &ClientFactory::run, this);
@@ -43,7 +44,7 @@ namespace P2P {
 
   bool ClientFactory::stop() {
     if (!this->executor_.valid()) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PClientFactory, __func__, "P2P Client Factory not started.");
+      LOGERROR("P2P Client Factory not started.");
       return false;
     }
     this->io_context_.stop();

--- a/src/net/p2p/client.h
+++ b/src/net/p2p/client.h
@@ -22,7 +22,7 @@ namespace P2P {
    * ClientFactory doesn't necesarily "own" the client session, it only creates them in a shared manner.
    * Registration/Unregistration is responsibility of the Manager.
    */
-  class ClientFactory {
+  class ClientFactory : public Log::LogicalLocationProvider {
     private:
       /// io_context for the factory.
       net::io_context io_context_;
@@ -60,6 +60,8 @@ namespace P2P {
         connectorStrand_(io_context_.get_executor()),
         threadCount_(threadCount),
         manager_(manager) {}
+
+      virtual std::string getLogicalLocation() const; ///< Log instance from P2P
 
       /// Start the Factory.
       bool start();

--- a/src/net/p2p/discovery.cpp
+++ b/src/net/p2p/discovery.cpp
@@ -8,6 +8,8 @@ See the LICENSE.txt file in the project root for more information.
 #include "managerbase.h"
 
 namespace P2P {
+  std::string DiscoveryWorker::getLogicalLocation() const { return this->manager_.getLogicalLocation(); }
+
   void DiscoveryWorker::refreshRequestedNodes() {
     std::unique_lock lock(this->requestedNodesMutex_);
     for (auto it = this->requestedNodes_.begin(); it != this->requestedNodes_.end();) {
@@ -51,7 +53,7 @@ namespace P2P {
 
   bool DiscoveryWorker::discoverLoop() {
     bool discoveryPass = false;
-    Logger::logToDebug(LogType::INFO, Log::P2PDiscoveryWorker, __func__, "Discovery thread started minConnections: "
+    LOGINFO("Discovery thread started minConnections: "
                         + std::to_string(this->manager_.minConnections()) + " maxConnections: " + std::to_string(this->manager_.maxConnections()));
     uint64_t lastLogged = 0;
     while (!this->stopWorker_) {
@@ -63,13 +65,13 @@ namespace P2P {
       }
 
       if (lastLogged != sessionSize) {
-        Logger::logToDebug(LogType::INFO, Log::P2PDiscoveryWorker, __func__, "DiscoveryWorker current sessionSize: " + std::to_string(sessionSize));
+        LOGINFO("DiscoveryWorker current sessionSize: " + std::to_string(sessionSize));
         lastLogged = sessionSize;
       }
 
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       if (sessionSize >= this->manager_.maxConnections()) {
-         Logger::logToDebug(LogType::INFO, Log::P2PDiscoveryWorker, __func__, "Max connections reached, sleeping...");
+         LOGINFO("Max connections reached, sleeping...");
          std::this_thread::sleep_for(std::chrono::seconds(10));
          continue;
       }

--- a/src/net/p2p/discovery.h
+++ b/src/net/p2p/discovery.h
@@ -21,7 +21,7 @@ namespace P2P {
    * Worker class for the Discovery manager, as a separate thread.
    * Responsible for the process of actually discovering other nodes.
    */
-  class DiscoveryWorker {
+  class DiscoveryWorker : public Log::LogicalLocationProvider {
   private:
     /// Reference to the parent connection manager.
     ManagerBase& manager_;
@@ -96,6 +96,8 @@ namespace P2P {
 
     /// Destructor. Automatically stops the worker thread.
     ~DiscoveryWorker() { this->stop(); }
+
+    virtual std::string getLogicalLocation() const; ///< Log instance from P2P
 
     /// Start the discovery thread.
     void start();

--- a/src/net/p2p/managerdiscovery.cpp
+++ b/src/net/p2p/managerdiscovery.cpp
@@ -20,8 +20,7 @@ namespace P2P {
         handleAnswer(nodeId, message);
         break;
       default:
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                           "Invalid message type from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+        LOGERROR("Invalid message type from " + toString(nodeId) +
                            " closing session.");
         this->disconnectSession(nodeId);
         break;
@@ -39,8 +38,7 @@ namespace P2P {
         handleRequestNodesRequest(nodeId, message);
         break;
       default:
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                           "Invalid Request Command Type from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+        LOGERROR("Invalid Request Command Type from " + toString(nodeId) +
                            ", closing session.");
         this->disconnectSession(nodeId);
         break;
@@ -60,8 +58,7 @@ namespace P2P {
         handleRequestNodesAnswer(nodeId, message);
         break;
       default:
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                           "Invalid Answer Command Type from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+        LOGERROR("Invalid Answer Command Type from " + toString(nodeId) +
                            ", closing session.");
         this->disconnectSession(nodeId);
         break;
@@ -72,8 +69,7 @@ namespace P2P {
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     if (!RequestDecoder::ping(*message)) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Invalid ping request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Invalid ping request from " + toString(nodeId) +
                          " closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -85,8 +81,7 @@ namespace P2P {
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     if (!RequestDecoder::requestNodes(*message)) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Invalid requestNodes request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " closing session.");
+      LOGERROR("Invalid requestNodes request from " + toString(nodeId) + " closing session.");
       this->disconnectSession(nodeId);
       return;
     }
@@ -110,8 +105,7 @@ namespace P2P {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Answer to invalid request from " + toString(nodeId) +
                          " closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -125,8 +119,7 @@ namespace P2P {
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Answer to invalid request from " + toString(nodeId) +
                          " closing session.");
       this->disconnectSession(nodeId);
       return;

--- a/src/net/p2p/managernormal.cpp
+++ b/src/net/p2p/managernormal.cpp
@@ -49,7 +49,7 @@ namespace P2P{
           break;
       }
     } catch (std::exception const& ex) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__, "Closing session to " + toString(nodeId) + ": " + ex.what());
+      LOGERROR("Closing session to " + toString(nodeId) + ": " + ex.what());
       this->disconnectSession(nodeId);
     }
   }
@@ -77,9 +77,8 @@ namespace P2P{
         handleRequestBlockRequest(nodeId, message);
         break;
       default:
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                           "Invalid Request Command Type: " + std::to_string(message->command()) +
-                           " from: " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+        LOGERROR("Invalid Request Command Type: " + std::to_string(message->command()) +
+                           " from: " + toString(nodeId) +
                            ", closing session.");
         this->disconnectSession(nodeId);
         break;
@@ -109,9 +108,8 @@ namespace P2P{
         handleRequestBlockAnswer(nodeId, message);
         break;
       default:
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                           "Invalid Answer Command Type: " + std::to_string(message->command()) +
-                           " from: " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+        LOGERROR("Invalid Answer Command Type: " + std::to_string(message->command()) +
+                           " from: " + toString(nodeId) +
                            " , closing session.");
         this->disconnectSession(nodeId);
         break;
@@ -126,9 +124,8 @@ namespace P2P{
         handleInfoNotification(nodeId, message);
         break;
       default:
-        Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                           "Invalid Notification Command Type: " + std::to_string(message->command()) +
-                           " from: " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+        LOGERROR("Invalid Notification Command Type: " + std::to_string(message->command()) +
+                           " from: " + toString(nodeId) +
                            ", closing session.");
         this->disconnectSession(nodeId);
         break;
@@ -139,8 +136,7 @@ namespace P2P{
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     if (!RequestDecoder::ping(*message)) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Invalid ping request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Invalid ping request from " + toString(nodeId) +
                          " , closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -161,8 +157,7 @@ namespace P2P{
       const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     if (!RequestDecoder::requestNodes(*message)) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Invalid requestNodes request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Invalid requestNodes request from " + toString(nodeId) +
                          " , closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -185,8 +180,7 @@ namespace P2P{
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     if (!RequestDecoder::requestValidatorTxs(*message)) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Invalid requestValidatorTxs request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Invalid requestValidatorTxs request from " + toString(nodeId) +
                          " , closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -198,8 +192,7 @@ namespace P2P{
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
     if (!RequestDecoder::requestTxs(*message)) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Invalid requestTxs request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Invalid requestTxs request from " + toString(nodeId) +
                          " , closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -218,8 +211,7 @@ namespace P2P{
       if (!this->storage_.blockExists(heightToAdd)) break; // Stop at first block in the requested range that we don't have.
       requestedBlocks.push_back(this->storage_.getBlock(heightToAdd));
       bytesSpent += requestedBlocks.back()->getSize();
-      Logger::logToDebug(LogType::DEBUG, Log::P2PParser, __func__,
-                         "Uploading block " + std::to_string(heightToAdd) + " to " + toString(nodeId)
+      LOGDEBUG("Uploading block " + std::to_string(heightToAdd) + " to " + toString(nodeId)
                          + " (" + std::to_string(bytesSpent) + "/" + std::to_string(bytesLimit) + " bytes)");
       if (bytesSpent >= bytesLimit) break; // bytesLimit reached so stop appending blocks to the answer
     }
@@ -232,8 +224,7 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before doing anything else to avoid waiting for other locks.
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Answer to invalid request from " + toString(nodeId) +
                          " , closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -247,8 +238,7 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Answer to invalid request from " + toString(nodeId) +
                          " , closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -262,8 +252,7 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Answer to invalid request from " + toString(nodeId) +
                          " , closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -277,8 +266,7 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Answer to invalid request from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Answer to invalid request from " + toString(nodeId) +
                          " , closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -292,8 +280,7 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Answer to invalid request from " + nodeId.first.to_string() + ":" +
+      LOGERROR("Answer to invalid request from " + nodeId.first.to_string() + ":" +
                          std::to_string(nodeId.second) + " , closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -307,8 +294,7 @@ namespace P2P{
     std::unique_lock lock(this->requestsMutex_);
     if (!requests_.contains(message->id())) {
       lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Answer to invalid request from " + nodeId.first.to_string() + ":" +
+      LOGERROR("Answer to invalid request from " + nodeId.first.to_string() + ":" +
                          std::to_string(nodeId.second) + " , closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -337,8 +323,7 @@ namespace P2P{
       auto nodeInfo = NotificationDecoder::notifyInfo(*message);
       this->nodeConns_.incomingInfo(nodeId, nodeInfo, nodeType);
     } catch (std::exception &e) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-                         "Invalid infoNotification from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) +
+      LOGERROR("Invalid infoNotification from " + toString(nodeId) +
                          " , error: " + e.what() + " closing session.");
       this->disconnectSession(nodeId);
       return;
@@ -349,90 +334,69 @@ namespace P2P{
   // Somehow change to wait_for.
   std::vector<TxValidator> ManagerNormal::requestValidatorTxs(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::requestValidatorTxs());
-    Logger::logToDebug(LogType::TRACE, Log::P2PParser, __func__,
-                       "Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
+    LOGTRACE("Requesting nodes from " + toString(nodeId));
     auto requestPtr = this->sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
-      Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,
-        "Request to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " failed."
-      );
+      LOGWARNING("Request to " + toString(nodeId) + " failed.");
       return {};
     }
     auto answer = requestPtr->answerFuture();
     auto status = answer.wait_for(std::chrono::seconds(2)); // 2000ms timeout.
     if (status == std::future_status::timeout) {
-      Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,
-        "Request to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " timed out."
-      );
+      LOGWARNING("Request to " + toString(nodeId) + " timed out.");
       return {};
     }
     try {
       auto answerPtr = answer.get();
       return AnswerDecoder::requestValidatorTxs(*answerPtr, this->options_.getChainID());
     } catch (std::exception &e) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-        "Request to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " failed with error: " + e.what()
-      );
+      LOGERROR("Request to " + toString(nodeId) + " failed with error: " + e.what());
       return {};
     }
   }
 
   std::vector<TxBlock> ManagerNormal::requestTxs(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::requestTxs());
-    Logger::logToDebug(LogType::TRACE, Log::P2PParser, __func__,
-                       "Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
+    LOGTRACE("Requesting nodes from " + toString(nodeId));
     auto requestPtr = this->sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
-      Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,
-        "Request to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " failed."
-      );
+      LOGWARNING("Request to " + toString(nodeId) + " failed.");
       return {};
     }
     auto answer = requestPtr->answerFuture();
     auto status = answer.wait_for(std::chrono::seconds(2)); // 2000ms timeout.
     if (status == std::future_status::timeout) {
-      Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,
-        "Request to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " timed out."
-      );
+      LOGWARNING("Request to " + toString(nodeId) + " timed out.");
       return {};
     }
     try {
       auto answerPtr = answer.get();
       return AnswerDecoder::requestTxs(*answerPtr, this->options_.getChainID());
     } catch (std::exception &e) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-        "Request to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " failed with error: " + e.what()
-      );
+      LOGERROR("Request to " + toString(nodeId) + " failed with error: " + e.what());
       return {};
     }
   }
 
   NodeInfo ManagerNormal::requestNodeInfo(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::info(this->storage_.latest(), this->nodeConns_.getConnectedWithNodeType(), this->options_));
-    Logger::logToDebug(LogType::TRACE, Log::P2PParser, __func__,
-                       "Requesting nodes from " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second));
+    LOGTRACE("Requesting nodes from " + toString(nodeId));
     auto requestPtr = sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
-      Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,
-        "Request to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " failed."
-      );
+      LOGWARNING("Request to " + toString(nodeId) + " failed.");
       return {};
     }
     auto answer = requestPtr->answerFuture();
     auto status = answer.wait_for(std::chrono::seconds(2)); // 2000ms timeout.
     if (status == std::future_status::timeout) {
-      Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,
-        "Request to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " timed out."
-      );
+      LOGWARNING("Request to " + toString(nodeId) + " timed out.");
       return {};
     }
     try {
       auto answerPtr = answer.get();
       return AnswerDecoder::info(*answerPtr);
     } catch (std::exception &e) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-        "Request to " + nodeId.first.to_string() + ":" + std::to_string(nodeId.second) + " failed with error: " + e.what()
-      );
+      LOGERROR("Request to " + toString(nodeId) + " failed with error: " + e.what());
       return {};
     }
   }
@@ -443,26 +407,20 @@ namespace P2P{
     auto request = std::make_shared<const Message>(RequestEncoder::requestBlock(height, heightEnd, bytesLimit));
     auto requestPtr = sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
-      Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,
-        "RequestBlock to " + toString(nodeId) + " failed."
-      );
+      LOGWARNING("RequestBlock to " + toString(nodeId) + " failed.");
       return {};
     }
     auto answer = requestPtr->answerFuture();
     auto status = answer.wait_for(std::chrono::seconds(60)); // 60s timeout.
     if (status == std::future_status::timeout) {
-      Logger::logToDebug(LogType::WARNING, Log::P2PParser, __func__,
-        "RequestBlock to " + toString(nodeId) + " timed out."
-      );
+      LOGWARNING("RequestBlock to " + toString(nodeId) + " timed out.");
       return {};
     }
     try {
       auto answerPtr = answer.get();
       return AnswerDecoder::requestBlock(*answerPtr, this->options_.getChainID());
     } catch (std::exception &e) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PParser, __func__,
-        "RequestBlock to " + toString(nodeId) + " failed with error: " + e.what()
-      );
+      LOGERROR("RequestBlock to " + toString(nodeId) + " failed with error: " + e.what());
       return {};
     }
   }

--- a/src/net/p2p/server.h
+++ b/src/net/p2p/server.h
@@ -16,7 +16,7 @@ namespace P2P {
    * This class has the purpose of opening a tcp socket and listening for incoming connections.
    * Creating a new ServerSession for each connection.
    */
-  class ServerListener : public std::enable_shared_from_this<ServerListener> {
+  class ServerListener : public std::enable_shared_from_this<ServerListener>, public Log::LogicalLocationProvider {
     private:
       /// Reference to server io_context.
       net::io_context& io_context_;
@@ -43,14 +43,16 @@ namespace P2P {
         manager_(manager) {
          boost::system::error_code ec;
          acceptor_.open(endpoint.protocol(), ec); // Open the acceptor
-         if (ec) { Logger::logToDebug(LogType::ERROR, Log::P2PServerListener, __func__, "Open Acceptor: " + ec.message()); return; }
+         if (ec) { LOGERROR("Open Acceptor: " + ec.message()); return; }
          acceptor_.set_option(net::socket_base::reuse_address(true), ec); // Allow address reuse
-         if (ec) { Logger::logToDebug(LogType::ERROR, Log::P2PServerListener, __func__, "Set Option: " + ec.message()); return; }
+         if (ec) { LOGERROR("Set Option: " + ec.message()); return; }
          acceptor_.bind(endpoint, ec); // Bind to the server address
-         if (ec) { Logger::logToDebug(LogType::ERROR, Log::P2PServerListener, __func__, "Bind Acceptor: " + ec.message()); return; }
+         if (ec) { LOGERROR("Bind Acceptor: " + ec.message()); return; }
          acceptor_.listen(net::socket_base::max_listen_connections, ec); // Start listening
-         if (ec) { Logger::logToDebug(LogType::ERROR, Log::P2PServerListener, __func__, "Listen Acceptor: " + ec.message()); return; }
+         if (ec) { LOGERROR("Listen Acceptor: " + ec.message()); return; }
       }
+
+      virtual std::string getLogicalLocation() const; ///< Log instance from P2P
 
       void run();   ///< Start accepting incoming connections.
       void stop();  ///< Stop accepting incoming connections.
@@ -61,7 +63,7 @@ namespace P2P {
   * This class has the purpose of opening a tcp socket and listening for incoming connections.
   * Creating a new ServerSession for each connection.
   */
-  class Server {
+  class Server : public Log::LogicalLocationProvider {
     private:
       /// io_context for the server.
       net::io_context io_context_;
@@ -100,6 +102,8 @@ namespace P2P {
         threadCount_(threadCount),
         manager_(manager)
         {}
+
+      virtual std::string getLogicalLocation() const; ///< Log instance from P2P
 
       /// Start the Server.
       bool start();

--- a/src/net/p2p/session.cpp
+++ b/src/net/p2p/session.cpp
@@ -11,10 +11,11 @@ See the LICENSE.txt file in the project root for more information.
 
 namespace P2P {
 
+  std::string Session::getLogicalLocation() const { return manager_.getLogicalLocation(); }
+
   bool Session::handle_error(const std::string& func, const boost::system::error_code& ec) {
     /// TODO: return true/false depending on err code is necessary?
-    Logger::logToDebug(LogType::ERROR, Log::P2PSession, std::string(func),
-                       "Client Error Code: " + std::to_string(ec.value()) + " message: " + ec.message());
+    LOGERROR("Client Error Code: " + std::to_string(ec.value()) + " message: " + ec.message());
     if (ec != boost::system::errc::operation_canceled) {
       /// operation_canceled == close() was already called, we cannot close or deregister again.
       if (this->doneHandshake_) {
@@ -65,7 +66,7 @@ namespace P2P {
   void Session::finish_handshake(boost::system::error_code ec, std::size_t) {
     if (ec) { this->handle_error(__func__, ec); return; }
     if (this->inboundHandshake_.size() != 3) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PSession, __func__, "Invalid handshake size");
+      LOGERROR("Invalid handshake size");
       this->close();
       return;
     }
@@ -93,8 +94,7 @@ namespace P2P {
     if (ec) { this->handle_error(__func__, ec); return; }
     uint64_t messageSize = Utils::bytesToUint64(this->inboundHeader_);
     if (messageSize > this->maxMessageSize_) {
-      Logger::logToDebug(LogType::WARNING, Log::P2PSession, __func__,
-        "Message size too large: " + std::to_string(messageSize)
+      LOGWARNING("Message size too large: " + std::to_string(messageSize)
         + " max: " + std::to_string(this->maxMessageSize_) + " closing session..."
       );
       this->close();
@@ -157,10 +157,10 @@ namespace P2P {
 
   void Session::run() {
     if (this->connectionType_ == ConnectionType::INBOUND) {
-      Logger::logToDebug(LogType::INFO, Log::P2PSession, __func__, "Starting new inbound session");
+      LOGINFO("Starting new inbound session");
       boost::asio::dispatch(this->socket_.get_executor(), std::bind(&Session::write_handshake, shared_from_this()));
     } else {
-      Logger::logToDebug(LogType::INFO, Log::P2PSession, __func__, "Starting new outbound session");
+      LOGINFO("Starting new outbound session");
       boost::asio::dispatch(this->socket_.get_executor(), std::bind(&Session::do_connect, shared_from_this()));
     }
   }
@@ -174,19 +174,19 @@ namespace P2P {
     // Cancel all pending operations.
     this->socket_.cancel(ec);
     if (ec) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PSession, __func__, "Failed to cancel socket operations: " + ec.message());
+      LOGERROR("Failed to cancel socket operations: " + ec.message());
       return;
     }
     // Shutdown the socket;
     this->socket_.shutdown(net::socket_base::shutdown_both, ec);
     if (ec) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PSession, __func__, "Failed to shutdown socket: " + ec.message());
+      LOGERROR("Failed to shutdown socket: " + ec.message());
       return;
     }
     // Close the socket.
     this->socket_.close(ec);
     if (ec) {
-      Logger::logToDebug(LogType::ERROR, Log::P2PSession, __func__, "Failed to close socket: " + ec.message());
+      LOGERROR("Failed to close socket: " + ec.message());
       return;
     }
   }

--- a/src/net/p2p/session.h
+++ b/src/net/p2p/session.h
@@ -33,7 +33,7 @@ namespace P2P {
   * It contains the basic functionality for reading and writing messages to the
   * socket.
   */
-  class Session : public std::enable_shared_from_this<Session> {
+  class Session : public std::enable_shared_from_this<Session>, public Log::LogicalLocationProvider {
     protected:
       /// The socket used to communicate with the client.
       net::ip::tcp::socket socket_;
@@ -167,6 +167,8 @@ namespace P2P {
           throw DynamicException("Session: Invalid connection type.");
         }
       }
+
+      virtual std::string getLogicalLocation() const; ///< Log instance from P2P
 
       /// Max message size
       const uint64_t maxMessageSize_ = 1024 * 1024 * 128; // (128 MB)

--- a/src/utils/db.cpp
+++ b/src/utils/db.cpp
@@ -14,7 +14,7 @@ DB::DB(const std::filesystem::path& path) {
   }
   auto status = rocksdb::DB::Open(this->opts_, path, &this->db_);
   if (!status.ok()) {
-    Logger::logToDebug(LogType::ERROR, Log::db, __func__, "Failed to open DB: " + status.ToString());
+    LOGERROR("Failed to open DB: " + status.ToString());
     throw DynamicException("Failed to open DB: " + status.ToString());
   }
 }

--- a/src/utils/db.h
+++ b/src/utils/db.h
@@ -205,7 +205,7 @@ public:
     rocksdb::Slice valueSlice(reinterpret_cast<const char*>(value.data()), value.size());
     auto status = this->db_->Put(rocksdb::WriteOptions(), keySlice, valueSlice);
     if (!status.ok()) {
-      Logger::logToDebug(LogType::ERROR, Log::db, __func__, "Failed to put key: " + Hex::fromBytes(keyTmp).get());
+      LOGERROR("Failed to put key: " + Hex::fromBytes(keyTmp).get());
       return false;
     }
     return true;
@@ -225,7 +225,7 @@ public:
     rocksdb::Slice keySlice(reinterpret_cast<const char*>(keyTmp.data()), keyTmp.size());
     auto status = this->db_->Delete(rocksdb::WriteOptions(), keySlice);
     if (!status.ok()) {
-      Logger::logToDebug(LogType::ERROR, Log::db, __func__, "Failed to delete key: " + Hex::fromBytes(keyTmp).get());
+      LOGERROR("Failed to delete key: " + Hex::fromBytes(keyTmp).get());
       return false;
     }
     return true;

--- a/src/utils/finalizedblock.cpp
+++ b/src/utils/finalizedblock.cpp
@@ -10,7 +10,7 @@ See the LICENSE.txt file in the project root for more information.
 
 FinalizedBlock FinalizedBlock::fromBytes(const BytesArrView bytes, const uint64_t& requiredChainId) {
   try {
-    Logger::logToDebug(LogType::TRACE, Log::finalizedBlock, __func__, "Deserializing block...");
+    SLOGTRACE("Deserializing block...");
     // Verify minimum size for a valid block
     if (bytes.size() < 217) throw std::runtime_error("Invalid block size - too short");
     // Parsing fixed-size fields
@@ -23,7 +23,7 @@ FinalizedBlock FinalizedBlock::fromBytes(const BytesArrView bytes, const uint64_
     uint64_t nHeight = Utils::bytesToUint64(bytes.subspan(201, 8));
     uint64_t txValidatorStart = Utils::bytesToUint64(bytes.subspan(209, 8));
 
-    Logger::logToDebug(LogType::TRACE, Log::finalizedBlock, __func__, "Deserializing transactions...");
+    SLOGTRACE("Deserializing transactions...");
 
     std::vector<TxBlock> txs;
     std::vector<TxValidator> txValidators;
@@ -112,7 +112,7 @@ FinalizedBlock FinalizedBlock::fromBytes(const BytesArrView bytes, const uint64_
       index += 4;
       txValidators.emplace_back(bytes.subspan(index, txSize), requiredChainId);
       if (txValidators.back().getNHeight() != nHeight) {
-        Logger::logToDebug(LogType::ERROR, Log::mutableBlock, __func__, "Invalid validator tx height");
+        SLOGERROR("Invalid validator tx height");
         throw DynamicException("Invalid validator tx height");
       }
       index += txSize;
@@ -151,7 +151,7 @@ FinalizedBlock FinalizedBlock::fromBytes(const BytesArrView bytes, const uint64_
         bytes.size()
     };
   } catch (const std::exception &e) {
-    Logger::logToDebug(LogType::ERROR, Log::finalizedBlock, __func__, "Error when deserializing a FinalizedBlock: " + std::string(e.what()));
+    SLOGERROR("Error when deserializing a FinalizedBlock: " + std::string(e.what()));
     throw std::runtime_error(std::string("Error when deserializing a FinalizedBlock: ") + e.what());
   }
 }

--- a/src/utils/finalizedblock.h
+++ b/src/utils/finalizedblock.h
@@ -79,7 +79,7 @@ class FinalizedBlock {
         validatorMerkleRoot_(std::move(validatorMerkleRoot)), txMerkleRoot_(std::move(txMerkleRoot)),
         timestamp_(timestamp), nHeight_(nHeight),
         txValidators_(std::move(txValidators)), txs_(std::move(txs)), hash_(std::move(hash)), size_(size)
-    {Logger::logToDebug(LogType::TRACE, Log::finalizedBlock, __func__, "Finalized block moved");}
+    {LOGTRACE("Finalized block moved");}
 
     /**
      * Move constructor.
@@ -98,7 +98,7 @@ class FinalizedBlock {
       txs_(std::move(block.txs_)),
       hash_(std::move(block.hash_)),
       size_(block.size_)
-    {Logger::logToDebug(LogType::TRACE, Log::finalizedBlock, __func__, "Finalized block moved");}
+    {LOGTRACE("Finalized block moved");}
 
     /**
      * Copy constructor.
@@ -117,7 +117,7 @@ class FinalizedBlock {
       txs_(block.txs_),
       hash_(block.hash_),
       size_(block.size_)
-    {Logger::logToDebug(LogType::TRACE, Log::finalizedBlock, __func__, "Finalized block copied");}
+    {LOGTRACE("Finalized block copied");}
 
 
     static FinalizedBlock fromBytes(const BytesArrView bytes, const uint64_t& requiredChainId);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -12,8 +12,6 @@ See the LICENSE.txt file in the project root for more information.
 std::mutex log_lock;
 std::mutex debug_mutex;
 
-std::atomic<bool> Utils::logToCout = false;
-
 void fail(const std::string& cl, std::string&& func, boost::beast::error_code ec, const char* what) {
   Logger::logToDebug(LogType::ERROR, cl, std::move(func), std::string("HTTP Fail ") + what + " : " + ec.message());
 }
@@ -51,12 +49,11 @@ BytesArrView Utils::getFunctionArgs(const evmc_message& msg) {
 }
 
 void Utils::safePrint(std::string_view str) {
-  if (!Utils::logToCout) return; // Never print if we are in a test
   Log::safePrint(str);
 }
 
 void Utils::safePrintTest(std::string_view str) {
-  Log::safePrint(str);
+  Log::safePrintTest(str);
 }
 
 Hash Utils::sha3(const BytesArrView input) {
@@ -796,7 +793,7 @@ Bytes Utils::padRightBytes(const BytesArrView bytes, unsigned int charAmount, ui
 
 json Utils::readConfigFile() {
   if (!std::filesystem::exists("config.json")) {
-    Logger::logToDebug(LogType::INFO, Log::utils, __func__, "No config file found, generating default");
+    SLOGINFO("No config file found, generating default");
     json config;
     config["rpcport"] = 8080;
     config["p2pport"] = 8081;

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -416,8 +416,6 @@ namespace Utils {
     using type = typename makeTupleTypeHelper<std::tuple<>, EventParam<Args, Flags>...>::type;  ///< Typedef.
   };
 
-  extern std::atomic<bool> logToCout; ///< Indicates whether logging to stdout is allowed (for safePrint()).
-
   /**
    * %Log a string to a file called `log.txt`.
    * @param str The string to log.

--- a/tests/core/dumpmanager.cpp
+++ b/tests/core/dumpmanager.cpp
@@ -44,7 +44,7 @@ namespace TDumpManager {
         blockchainWrapper.state.dumpStartWorker();
         // create 1001 blocks
         for (uint64_t i = 0; i < 1001; ++i) {
-          std::cout << "Creating block: " << i << std::endl;
+          GLOGTRACE("Creating block: " + std::to_string(i));
           auto block = createValidBlock(validatorPrivKeysState,
                                         blockchainWrapper.state,
                                         blockchainWrapper.storage);

--- a/tests/core/rdpos.cpp
+++ b/tests/core/rdpos.cpp
@@ -504,7 +504,9 @@ namespace TRdPoS {
   }
 
   TEST_CASE("rdPoS class with Network and rdPoSWorker Functionality, move 10 blocks forward", "[core][rdpos][net][heavy]") {
+    TempEchoToCout tec;
     TempLogLevel tll(LogType::TRACE);
+    GLOGINFOP("FIXME: Enabling TRACE and echo to cout to debug failing networked rdPoS test. Remove this later.");
 
     PrivKey chainOwnerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
     Address chainOwnerAddress = Secp256k1::toAddress(Secp256k1::toUPub(chainOwnerPrivKey));

--- a/tests/sdktestsuite.cpp
+++ b/tests/sdktestsuite.cpp
@@ -28,40 +28,33 @@ public:
 
   // Called when a test run is starting
   void testRunStarting(Catch::TestRunInfo const& testRunInfo) override {
-    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
-      "Starting test run: " + testRunInfo.name);
+    GLOGINFO("Starting test run: " + testRunInfo.name);
   }
 
   // Called when a test case is starting
   void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
-    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
-      "Starting TEST_CASE: " + testInfo.name);
+    GLOGINFO("Starting TEST_CASE: " + testInfo.name);
     testCaseName = testInfo.name;
   }
 
   // Called when a section is starting
   void sectionStarting(Catch::SectionInfo const& sectionInfo) override {
-    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
-      "[" + testCaseName + "]: Starting SECTION: " + sectionInfo.name);
+    GLOGINFO("[" + testCaseName + "]: Starting SECTION: " + sectionInfo.name);
   }
 
   void sectionEnded(Catch::SectionStats const& sectionStats) override {
-    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
-      "[" + testCaseName + "]: Finished SECTION: " + sectionStats.sectionInfo.name);
+    GLOGINFO("[" + testCaseName + "]: Finished SECTION: " + sectionStats.sectionInfo.name);
   }
 
   // Called when a test case has ended
   void testCaseEnded(Catch::TestCaseStats const& testCaseStats) override {
-    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
-      "Finished TEST_CASE: " + testCaseStats.testInfo->name);
+    GLOGINFO("Finished TEST_CASE: " + testCaseStats.testInfo->name);
     testCaseName = "NONE";
   }
 
   // Called when a test run has ended
   void testRunEnded(Catch::TestRunStats const& testRunStats) override {
-    Logger::logToDebug(LogType::INFO, Log::sdkTestSuite, __func__,
-      "Finished test run: " + std::to_string(testRunStats.totals.testCases.total())
-      + " test cases run.");
+    GLOGINFO("Finished test run: " + std::to_string(testRunStats.totals.testCases.total()) + " test cases run.");
   }
 };
 

--- a/tests/sdktestsuite.hpp
+++ b/tests/sdktestsuite.hpp
@@ -45,10 +45,10 @@ struct TestAccount {
 class SDKTestSuite {
   private:
     const Options options_;      ///< Options singleton.
+    P2P::ManagerNormal p2p_;     ///< P2P connection manager. NOTE: p2p_ has to be constructed first due to getLogicalLocation()
     DB db_;                      ///< Database.
     Storage storage_;            ///< Blockchain storage.
     State state_;                ///< Blockchain state.
-    P2P::ManagerNormal p2p_;     ///< P2P connection manager.
     HTTPServer http_;            ///< HTTP server.
 
     /// Owner of the chain (0x00dead00...).
@@ -79,7 +79,7 @@ class SDKTestSuite {
     explicit SDKTestSuite(const Options& options) :
       options_(options),
       db_(std::get<0>(DumpManager::getBestStateDBPath(this->options_))),
-      storage_(options_),
+      storage_(p2p_.getLogicalLocation(),options_),
       state_(db_, storage_, p2p_, std::get<1>(DumpManager::getBestStateDBPath(this->options_)), options_),
       p2p_(boost::asio::ip::address::from_string("127.0.0.1"), options_, storage_, state_),
       http_(state_, storage_, p2p_, options_)


### PR DESCRIPTION
- Introduced several xLOGxxxx() macros that make logging/printing more informative and convenient
- When logging in the context of a running node, print an unique #nnn node ID, allowing log messages from different components (Storage, P2P, Consensus, etc.) to be mapped to the same running node when looking at networked test logs, for example
- Misc cleanups
- Added TempEchoToCout helper class to unit test suite that allows the echoing of test log messages to stdout (substitutes for uploading "bdk.log" from Github when running PR tests there)
- Enabled TempEchoToCout temporarily for the last rdPoS test, which is failing