### PR TITLE
Instrumentation to help resolving Issue #123

### DIFF
--- a/src/utils/strings.h
+++ b/src/utils/strings.h
@@ -184,6 +184,9 @@ class Hash : public FixedBytes<32> {
 
     /// Generate a CRYPTOGRAPHICALLY SECURE random 32-byte/256-bit hash.
     inline static Hash random() { Hash h; RAND_bytes(h.data_.data(), 32); return h; }
+
+    /// Overload operator<< (print it in test asserts, ...)
+    friend std::ostream& operator<<(std::ostream& os, const Hash& hash) { return os << hash.hex().get(); }
 };
 
 /// Abstraction of a functor (the first 4 bytes of a function's keccak hash). Inherits FixedBytes<4>.

--- a/tests/core/rdpos.cpp
+++ b/tests/core/rdpos.cpp
@@ -32,7 +32,7 @@ const std::vector<Hash> validatorPrivKeysRdpos {
 
 namespace TRdPoS {
   // Simple rdPoS execution, does not test network functionality neither validator execution (rdPoSWorker)
-  TEST_CASE("rdPoS Class", "[core][rdpos]") {
+  TEST_CASE("rdPoS Class", "[core][rdpos][sus]") {
     PrivKey chainOwnerPrivKey(Hex::toBytes("0xe89ef6409c467285bcae9f80ab1cfeb3487cfe61ab28fb7d36443e1daa0c2867"));
     Address chainOwnerAddress = Secp256k1::toAddress(Secp256k1::toUPub(chainOwnerPrivKey));
     std::string testDumpPath = Utils::getTestDumpPath();
@@ -107,6 +107,8 @@ namespace TRdPoS {
 
           // Process block on rdPoS.
           blockchainWrapper.state.rdposProcessBlock(block);
+
+          GLOGDEBUG("[TEST] block height: " + std::to_string(block.getNHeight()) + ", randomness: " + block.getBlockRandomness().hex().get());
 
           // Add the block to the storage.
           blockchainWrapper.storage.pushBack(std::move(block));


### PR DESCRIPTION
- add operator<< to Hash so that Catch2 asserts print Hash hex
- add [sus] tag to failing rdPoS test to help in running it in isolation, in a loop (#123); can be removed when it is fixed
- added a debug log to the failing rdPoS test that can help