### PR TITLE
Add routed messages support

### DIFF
--- a/src/net/p2p/managernormal.h
+++ b/src/net/p2p/managernormal.h
@@ -60,6 +60,18 @@ namespace P2P {
       void sendMessageToAll(const std::shared_ptr<const Message> message, const std::optional<NodeID>& originalSender);
 
       /**
+       * Send a message to specific NodeIDs in the network (may not be direct peer(s)).
+       * @param message The routable message that has the encoded NodeID(s) as its first data field.
+       * @param originalSender Node whose latest known peers won't receive the message from us (optional).
+       * @param fanout Maximum number of trusted nodes that have the recipient as a reported peer to replicate the message to.
+       */
+      void routeMessage(
+        const std::shared_ptr<const Message> message,
+        const std::optional<NodeID>& originalSender,
+        int fanout = 3
+      );
+
+      /**
        * Handle a `Ping` request.
        * @param session The session that sent the request.
        * @param message The request message to handle.


### PR DESCRIPTION
This branch will add routed messages (`ManagerNormal::routeMessage()`) support to the node.

Status:

This branch is a work-in-progress. There are no routed messages implemented yet, so this just implements the basic support in `ManagerNormal` and the `net/p2p/encoding` module, and documents how it is supposed to be used.

Rationale:

The `Broadcast` message concept and type is really meant for messages whose intented recipient is "every node", that is, they do not have a known and specific subset of `NodeID`s in the network as the inteded recipients. In that case, routing is straightforward: you send the message to all your peers unless the `Broadcast` message you received is a duplicate or you think a given direct peer already has the message.

The `Routed` message concept is intended for messages that have one or more NodeIDs encoded in the `Message` itself as the target recipient list. That means other nodes in the network that aren't the intended recipients will only receive the message if their help is needed to eventually reach the target node(s).

Since `Routed` messages need a list of recipients in them, this branch opts to keep the message header standard and fixed-size, and instead encode the recipient list as the first data field of the message itself. Thus, each message command and type (say `Notification`/`Notifying` type + `NotifyRoutedXYZ` command) will map to an encoder and decoder that is aware that the first field is necessarily a list of NodeIDs, which uses the standard NodeID encoder and decoder helpers from the `net/p2p/encoding` module. The routing decision on each hop is then implemented via cooperation between the implementation of `ManagerNormal::routeMessage()` in the P2P engine, and the message handler in `ManagerNormal::handleNotification()` that is contributed by the message application that runs on top of the basic P2P engine.