### PR TITLE
Parallelize requestValidatorTxs() requests to peers

### DIFF
--- a/src/core/consensus.cpp
+++ b/src/core/consensus.cpp
@@ -135,8 +135,8 @@ void Consensus::doValidatorBlock() {
       lastLog = std::make_unique<uint64_t>(validatorMempoolSize);
       LOGDEBUG("Block creator has: " + std::to_string(validatorMempoolSize) + " transactions in mempool");
     }
-    validatorMempoolSize = this->state_.rdposGetMempoolSize();
     requestValidatorTxsFromAllPeers();
+    validatorMempoolSize = this->state_.rdposGetMempoolSize();
     std::this_thread::sleep_for(std::chrono::microseconds(10));
   }
   LOGDEBUG("Validator ready to create a block");
@@ -308,8 +308,8 @@ void Consensus::doValidatorTx(const uint64_t& nHeight, const Validator& me) {
       lastLog = std::make_unique<uint64_t>(validatorMempoolSize);
       LOGDEBUG("Validator has: " + std::to_string(validatorMempoolSize) + " transactions in mempool");
     }
-    validatorMempoolSize = this->state_.rdposGetMempoolSize();
     requestValidatorTxsFromAllPeers();
+    validatorMempoolSize = this->state_.rdposGetMempoolSize();
     std::this_thread::sleep_for(std::chrono::microseconds(10));
   }
 

--- a/src/core/consensus.cpp
+++ b/src/core/consensus.cpp
@@ -137,7 +137,11 @@ void Consensus::doValidatorBlock() {
     }
     requestValidatorTxsFromAllPeers();
     validatorMempoolSize = this->state_.rdposGetMempoolSize();
-    std::this_thread::sleep_for(std::chrono::microseconds(10));
+    if (validatorMempoolSize == this->state_.rdposGetMinValidators() * 2 || this->stop_) {
+      break;
+    }
+    // Wait a significant amount of time before firing off another batch of network requests to all peers
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   LOGDEBUG("Validator ready to create a block");
 
@@ -310,7 +314,11 @@ void Consensus::doValidatorTx(const uint64_t& nHeight, const Validator& me) {
     }
     requestValidatorTxsFromAllPeers();
     validatorMempoolSize = this->state_.rdposGetMempoolSize();
-    std::this_thread::sleep_for(std::chrono::microseconds(10));
+    if (validatorMempoolSize == this->state_.rdposGetMinValidators() * 2 || this->stop_) {
+      break;
+    }
+    // Wait a significant amount of time before firing off another batch of network requests to all peers
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 
   LOGDEBUG("Broadcasting random transaction");

--- a/src/core/consensus.h
+++ b/src/core/consensus.h
@@ -10,8 +10,6 @@ See the LICENSE.txt file in the project root for more information.
 
 #include "state.h" // rdpos.h -> utils/tx.h -> ecdsa.h -> utils.h -> strings.h, logger.h, (libs/json.hpp -> boost/unordered/unordered_flat_map.hpp)
 
-// TODO: tests for Consensus (if necessary)
-
 /// Class responsible for processing blocks and transactions.
 class Consensus : public Log::LogicalLocationProvider {
   private:
@@ -22,6 +20,13 @@ class Consensus : public Log::LogicalLocationProvider {
 
     std::future<void> loopFuture_;  ///< Future object holding the thread for the consensus loop.
     std::atomic<bool> stop_ = false; ///< Flag for stopping the consensus processing.
+
+    boost::asio::thread_pool threadPool_; ///< Thread pool for async tasks
+
+    /**
+     * Pull all validator votes known by all direct peers and into the blockchain state.
+     */
+    void requestValidatorTxsFromAllPeers();
 
     /**
      * Create and broadcast a Validator block (called by validatorLoop()).
@@ -47,8 +52,12 @@ class Consensus : public Log::LogicalLocationProvider {
      * @param storage Reference to the blockchain storage.
      * @param options Reference to the Options singleton.
      */
-    explicit Consensus(State& state, P2P::ManagerNormal& p2p, const Storage& storage, const Options& options) :
-      state_(state), p2p_(p2p), storage_(storage), options_(options) {}
+    explicit Consensus(State& state, P2P::ManagerNormal& p2p, const Storage& storage, const Options& options);
+
+    /**
+     * Destructor.
+     */
+    virtual ~Consensus();
 
     std::string getLogicalLocation() const override { return p2p_.getLogicalLocation(); } ///< Log instance from P2P
 

--- a/src/core/consensus.h
+++ b/src/core/consensus.h
@@ -21,7 +21,7 @@ class Consensus : public Log::LogicalLocationProvider {
     std::future<void> loopFuture_;  ///< Future object holding the thread for the consensus loop.
     std::atomic<bool> stop_ = false; ///< Flag for stopping the consensus processing.
 
-    boost::asio::thread_pool threadPool_; ///< Thread pool for async tasks
+    std::unique_ptr<boost::asio::thread_pool> threadPool_; ///< Thread pool for async tasks
 
     /**
      * Pull all validator votes known by all direct peers and into the blockchain state.

--- a/src/core/rdpos.cpp
+++ b/src/core/rdpos.cpp
@@ -193,7 +193,7 @@ TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
   }
 
   if (tx.getNHeight() != this->storage_.latest()->getNHeight() + 1) {
-    LOGERROR("TxValidator is not for the next block. Expected: "
+    LOGXTRACE("TxValidator is not for the next block. Expected: "
       + std::to_string(this->storage_.latest()->getNHeight() + 1)
       + " Got: " + std::to_string(tx.getNHeight())
     );
@@ -209,7 +209,7 @@ TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
     }
   }
   if (!participates) {
-    LOGERROR("TxValidator sender is not a validator or is not participating in this rdPoS round.");
+    LOGTRACE("TxValidator sender is not a validator or is not participating in this rdPoS round.");
     return TxStatus::InvalidUnexpected;
   }
 
@@ -226,7 +226,7 @@ TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
 
   if (txs.size() == 1) { // We already have one transaction from this sender, check if it is the same function.
     if (txs[0].getFunctor() == tx.getFunctor()) {
-      LOGERROR("TxValidator sender already has a transaction for this function.");
+      LOGTRACE("TxValidator sender already has a transaction for this function.");
       return TxStatus::InvalidRedundant;
     }
     this->validatorMempool_.emplace(tx.hash(), tx);
@@ -234,7 +234,7 @@ TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
   }
 
   // We already have two transactions from this sender, it is the max we can have per validator.
-  LOGERROR("TxValidator sender already has two transactions.");
+  LOGTRACE("TxValidator sender already has two transactions.");
   return TxStatus::InvalidRedundant;
 }
 

--- a/src/core/rdpos.cpp
+++ b/src/core/rdpos.cpp
@@ -209,7 +209,7 @@ TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
     }
   }
   if (!participates) {
-    LOGTRACE("TxValidator sender is not a validator or is not participating in this rdPoS round.");
+    LOGXTRACE("TxValidator sender is not a validator or is not participating in this rdPoS round.");
     return TxStatus::InvalidUnexpected;
   }
 

--- a/src/core/rdpos.cpp
+++ b/src/core/rdpos.cpp
@@ -188,7 +188,7 @@ Hash rdPoS::processBlock(const FinalizedBlock& block) {
 
 TxStatus rdPoS::addValidatorTx(const TxValidator& tx) {
   if (this->validatorMempool_.contains(tx.hash())) {
-    LOGTRACE("TxValidator already exists in mempool.");
+    LOGXTRACE("TxValidator already exists in mempool.");
     return TxStatus::ValidExisting;
   }
 

--- a/src/core/state.cpp
+++ b/src/core/state.cpp
@@ -375,23 +375,25 @@ BlockValidationStatus State::tryProcessNextBlock(FinalizedBlock&& block) {
   ContractGlobals::blockHeight_ = block.getNHeight();
   ContractGlobals::blockTimestamp_ = block.getTimestamp();
 
+  std::string blockNumStr = std::to_string(block.getNHeight());
+  std::string blockHashStr = block.getHash().hex().get();
+
   // Process transactions of the block within the current state
+  LOGTRACE("Block " + blockHashStr + " (#" + blockNumStr + ") processing...");
   uint64_t txIndex = 0;
   for (auto const& tx : block.getTxs()) {
     this->processTransaction(tx, blockHash, txIndex, block.getBlockRandomness());
+    LOGTRACE("Transaction " + tx.hash().hex().get() + " for block " + blockNumStr + " processed");
     txIndex++;
   }
 
   // Process rdPoS State
   this->rdpos_.processBlock(block);
 
+  LOGINFO("Block " + blockHashStr + " (#" + blockNumStr + ") processed");
+
   // Refresh the mempool based on the block transactions
   this->refreshMempool(block);
-  LOGINFO("Block " + block.getHash().hex().get() + " processed successfully.");
-  Utils::safePrint("Block: " + block.getHash().hex().get() + " height: " + std::to_string(block.getNHeight()) + " was added to the blockchain");
-  for (const auto& tx : block.getTxs()) {
-    Utils::safePrint("Transaction: " + tx.hash().hex().get() + " was accepted in the blockchain");
-  }
 
   // Move block to storage
   this->storage_.pushBlock(std::move(block));

--- a/src/net/p2p/managerbase.cpp
+++ b/src/net/p2p/managerbase.cpp
@@ -264,10 +264,14 @@ namespace P2P {
       LOGDEBUG("Peer " + toString(nodeId) + " is a discovery node, cannot send request");
       return nullptr;
     }
-    std::unique_lock lockRequests(this->requestsMutex_);
-    requests_[message->id()] = std::make_shared<Request>(message->command(), message->id(), session->hostNodeId(), message);
+
     session->write(message);
-    return requests_[message->id()];
+
+    // Insert the new request in the active bucket.
+    // If the active bucket is full, clear the old bucket and make it the new active bucket.
+    auto request = std::make_shared<Request>(message->command(), message->id(), session->hostNodeId(), message);
+    insertRequest(request);
+    return request;
   }
 
   // ManagerBase::answerSession doesn't change sessions_ map, but we still need to
@@ -413,6 +417,12 @@ namespace P2P {
     //   objects and the entire Boost ASIO engine are fully gone.
 
     LOGDEBUG("Net engine destroyed");
+
+    // We don't need the requests_ cache anymore so free up that memory.
+    std::unique_lock lockRequests(this->requestsMutex_);
+    requests_[0].clear();
+    requests_[1].clear();
+    activeRequests_ = 0;
   }
 
   bool ManagerBase::isActive() const {
@@ -717,5 +727,41 @@ namespace P2P {
     // Start and run a session.
     // It is probably better to have asio::post inside the sessions mutex to sync with ManagerBase::stop().
     std::make_shared<Session>(std::move(socket), ConnectionType::INBOUND, *this)->run();
+  }
+
+  void ManagerBase::insertRequest(const std::shared_ptr<Request>& request) {
+    // The previous logic would silently overwrite the previous entry in case of an (improbable)
+    // request ID collision; this logic is retained here, since lookups will be directed to the
+    // active bucket first (so a colliding entry that is in the older bucket is shadowed anyway).
+    std::unique_lock lock(this->requestsMutex_);
+    requests_[activeRequests_][request->id()] = request;
+    if (requests_[activeRequests_].size() >= REQUEST_BUCKET_SIZE_LIMIT) {
+      activeRequests_ = 1 - activeRequests_;
+      requests_[activeRequests_].clear();
+    }
+  }
+
+  void ManagerBase::handleRequestAnswer(const NodeID& nodeId, const std::shared_ptr<const Message>& message) {
+    RequestID requestId = message->id();
+    std::unique_lock lock(this->requestsMutex_);
+    // Search for the request in both buckets, starting with the active bucket.
+    // If found, set its answer and return.
+    for (int i = 0; i < 2; ++i) {
+      auto& bucket = requests_[(activeRequests_ + i) % 2];
+      auto it = bucket.find(requestId);
+      if (it != bucket.end()) {
+        std::shared_ptr<Request>& req = it->second;
+        req->setAnswer(message);
+        return;
+      }
+    }
+    // Receiving an answer for a request ID that can't be found locally is always an error.
+    // This could legitimately happen if the request storage is too small for actual request traffic,
+    // so make sure request storage is oversized at all times by a factor of at least 10.
+    // If there is a need to optimize memory usage, buckets can be instead allocated dynamically as
+    // they are needed (e.g. in a deque) and an expiration timestamp can be associated with each bucket.
+    lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
+    LOGERROR("Answer to invalid request from " + toString(nodeId) + " closing session.");
+    this->disconnectSession(nodeId);
   }
 }

--- a/src/net/p2p/managerbase.cpp
+++ b/src/net/p2p/managerbase.cpp
@@ -627,7 +627,7 @@ namespace P2P {
       return;
     }
     auto request = std::make_shared<const Message>(RequestEncoder::ping());
-    LOGTRACE("Pinging " + toString(nodeId));
+    LOGXTRACE("Pinging " + toString(nodeId));
     auto requestPtr = sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) throw DynamicException(
       "Failed to send ping to " + toString(nodeId)
@@ -643,7 +643,7 @@ namespace P2P {
       return {};
     }
     auto request = std::make_shared<const Message>(RequestEncoder::requestNodes());
-    LOGTRACE("Requesting nodes from " + toString(nodeId));
+    LOGXTRACE("Requesting nodes from " + toString(nodeId));
     auto requestPtr = sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
       LOGDEBUG("Request to " + toString(nodeId) + " failed.");

--- a/src/net/p2p/managerbase.cpp
+++ b/src/net/p2p/managerbase.cpp
@@ -126,8 +126,11 @@ namespace P2P {
     // Stop the IO context, which should error out anything that it is still doing, then join with the threadpool,
     //   which will ensure the io_context object has completely stopped, even if it would still be managing any
     //   kind of resource.
+    LOGXTRACE("Net engine stopping - work guard");
     work_guard_.reset();
+    LOGXTRACE("Net engine stopping - io context");
     io_context_.stop();
+    LOGXTRACE("Net engine stopping - thread pool");
     threadPool_.join();
 
     LOGTRACE("Net engine stopped");
@@ -423,6 +426,7 @@ namespace P2P {
     requests_[0].clear();
     requests_[1].clear();
     activeRequests_ = 0;
+    lockRequests.unlock();
   }
 
   bool ManagerBase::isActive() const {

--- a/src/net/p2p/managerbase.h
+++ b/src/net/p2p/managerbase.h
@@ -192,7 +192,7 @@ namespace P2P {
       /// Start P2P::Server and P2P::ClientFactory.
       virtual void start();
 
-      ///< Stop the P2P::Server and P2P::ClientFactory.
+      /// Stop the P2P::Server and P2P::ClientFactory.
       virtual void stop();
 
       /**

--- a/src/net/p2p/managerdiscovery.cpp
+++ b/src/net/p2p/managerdiscovery.cpp
@@ -102,29 +102,13 @@ namespace P2P {
   void ManagerDiscovery::handlePingAnswer(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    std::unique_lock lock(this->requestsMutex_);
-    if (!requests_.contains(message->id())) {
-      lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      LOGERROR("Answer to invalid request from " + toString(nodeId) +
-                         " closing session.");
-      this->disconnectSession(nodeId);
-      return;
-    }
-    requests_[message->id()]->setAnswer(message);
+    handleRequestAnswer(nodeId, message);
   }
 
   void ManagerDiscovery::handleRequestNodesAnswer(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    std::unique_lock lock(this->requestsMutex_);
-    if (!requests_.contains(message->id())) {
-      lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      LOGERROR("Answer to invalid request from " + toString(nodeId) +
-                         " closing session.");
-      this->disconnectSession(nodeId);
-      return;
-    }
-    requests_[message->id()]->setAnswer(message);
+    handleRequestAnswer(nodeId, message);
   }
 };
 

--- a/src/net/p2p/managernormal.cpp
+++ b/src/net/p2p/managernormal.cpp
@@ -334,7 +334,7 @@ namespace P2P{
   // Somehow change to wait_for.
   std::vector<TxValidator> ManagerNormal::requestValidatorTxs(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::requestValidatorTxs());
-    LOGTRACE("Requesting validatorTxs from " + toString(nodeId));
+    LOGXTRACE("Requesting validatorTxs from " + toString(nodeId));
     auto requestPtr = this->sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
       LOGDEBUG("Request to " + toString(nodeId) + " failed.");
@@ -356,7 +356,7 @@ namespace P2P{
 
   std::vector<TxBlock> ManagerNormal::requestTxs(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::requestTxs());
-    LOGTRACE("Requesting txs from " + toString(nodeId));
+    LOGXTRACE("Requesting txs from " + toString(nodeId));
     auto requestPtr = this->sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
       LOGDEBUG("Request to " + toString(nodeId) + " failed.");
@@ -378,7 +378,7 @@ namespace P2P{
 
   NodeInfo ManagerNormal::requestNodeInfo(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::info(this->storage_.latest(), this->nodeConns_.getConnectedWithNodeType(), this->options_));
-    LOGTRACE("Requesting nodes from " + toString(nodeId));
+    LOGXTRACE("Requesting nodes from " + toString(nodeId));
     auto requestPtr = sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
       LOGDEBUG("Request to " + toString(nodeId) + " failed.");

--- a/src/net/p2p/managernormal.cpp
+++ b/src/net/p2p/managernormal.cpp
@@ -334,7 +334,7 @@ namespace P2P{
   // Somehow change to wait_for.
   std::vector<TxValidator> ManagerNormal::requestValidatorTxs(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::requestValidatorTxs());
-    LOGTRACE("Requesting nodes from " + toString(nodeId));
+    LOGTRACE("Requesting validatorTxs from " + toString(nodeId));
     auto requestPtr = this->sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
       LOGDEBUG("Request to " + toString(nodeId) + " failed.");
@@ -356,7 +356,7 @@ namespace P2P{
 
   std::vector<TxBlock> ManagerNormal::requestTxs(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::requestTxs());
-    LOGTRACE("Requesting nodes from " + toString(nodeId));
+    LOGTRACE("Requesting txs from " + toString(nodeId));
     auto requestPtr = this->sendRequestTo(nodeId, request);
     if (requestPtr == nullptr) {
       LOGDEBUG("Request to " + toString(nodeId) + " failed.");

--- a/src/net/p2p/managernormal.cpp
+++ b/src/net/p2p/managernormal.cpp
@@ -221,85 +221,37 @@ namespace P2P{
   void ManagerNormal::handlePingAnswer(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    std::unique_lock lock(this->requestsMutex_);
-    if (!requests_.contains(message->id())) {
-      lock.unlock(); // Unlock before doing anything else to avoid waiting for other locks.
-      LOGDEBUG("Answer to invalid request from " + toString(nodeId) +
-                         " , closing session.");
-      this->disconnectSession(nodeId);
-      return;
-    }
-    requests_[message->id()]->setAnswer(message);
+    handleRequestAnswer(nodeId, message);
   }
 
   void ManagerNormal::handleInfoAnswer(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    std::unique_lock lock(this->requestsMutex_);
-    if (!requests_.contains(message->id())) {
-      lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      LOGDEBUG("Answer to invalid request from " + toString(nodeId) +
-                         " , closing session.");
-      this->disconnectSession(nodeId);
-      return;
-    }
-    requests_[message->id()]->setAnswer(message);
+    handleRequestAnswer(nodeId, message);
   }
 
   void ManagerNormal::handleRequestNodesAnswer(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    std::unique_lock lock(this->requestsMutex_);
-    if (!requests_.contains(message->id())) {
-      lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      LOGDEBUG("Answer to invalid request from " + toString(nodeId) +
-                         " , closing session.");
-      this->disconnectSession(nodeId);
-      return;
-    }
-    requests_[message->id()]->setAnswer(message);
+    handleRequestAnswer(nodeId, message);
   }
 
   void ManagerNormal::handleTxValidatorAnswer(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    std::unique_lock lock(this->requestsMutex_);
-    if (!requests_.contains(message->id())) {
-      lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      LOGDEBUG("Answer to invalid request from " + toString(nodeId) +
-                         " , closing session.");
-      this->disconnectSession(nodeId);
-      return;
-    }
-    requests_[message->id()]->setAnswer(message);
+    handleRequestAnswer(nodeId, message);
   }
 
   void ManagerNormal::handleTxAnswer(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    std::unique_lock lock(this->requestsMutex_);
-    if (!requests_.contains(message->id())) {
-      lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      LOGDEBUG("Answer to invalid request from " + nodeId.first.to_string() + ":" +
-                         std::to_string(nodeId.second) + " , closing session.");
-      this->disconnectSession(nodeId);
-      return;
-    }
-    requests_[message->id()]->setAnswer(message);
+    handleRequestAnswer(nodeId, message);
   }
 
   void ManagerNormal::handleRequestBlockAnswer(
     const NodeID &nodeId, const std::shared_ptr<const Message>& message
   ) {
-    std::unique_lock lock(this->requestsMutex_);
-    if (!requests_.contains(message->id())) {
-      lock.unlock(); // Unlock before calling logToDebug to avoid waiting for the lock in the logToDebug function.
-      LOGDEBUG("Answer to invalid request from " + nodeId.first.to_string() + ":" +
-                         std::to_string(nodeId.second) + " , closing session.");
-      this->disconnectSession(nodeId);
-      return;
-    }
-    requests_[message->id()]->setAnswer(message);
+    handleRequestAnswer(nodeId, message);
   }
 
   void ManagerNormal::handleInfoNotification(
@@ -323,15 +275,14 @@ namespace P2P{
       auto nodeInfo = NotificationDecoder::notifyInfo(*message);
       this->nodeConns_.incomingInfo(nodeId, nodeInfo, nodeType);
     } catch (std::exception &e) {
-      LOGDEBUG("Invalid infoNotification from " + toString(nodeId) +
-                         " , error: " + e.what() + " closing session.");
+      LOGDEBUG(
+        "Invalid infoNotification from " + toString(nodeId) +
+        " , error: " + e.what() + " closing session."
+      );
       this->disconnectSession(nodeId);
-      return;
     }
   }
 
-  // TODO: Both ping and requestNodes is a blocking call on .wait()
-  // Somehow change to wait_for.
   std::vector<TxValidator> ManagerNormal::requestValidatorTxs(const NodeID& nodeId) {
     auto request = std::make_shared<const Message>(RequestEncoder::requestValidatorTxs());
     LOGXTRACE("Requesting validatorTxs from " + toString(nodeId));

--- a/src/net/p2p/session.cpp
+++ b/src/net/p2p/session.cpp
@@ -82,12 +82,16 @@ namespace P2P {
     // Log the Session failure
     if (this->nodeId_.second > 0) {
       // nodeId_ is valid
-      LOGDEBUG("Peer connection " + toString(this->nodeId_) + " error (" +
-               func + ", " + std::to_string(ec.value()) + "): " + ec.message());
+      LOGXTRACE(
+        "Peer connection " + toString(this->nodeId_) + " error (" +
+        func + ", " + std::to_string(ec.value()) + "): " + ec.message()
+      );
     } else {
       // nodeId_ is not resolved, so use the next best thing (addressAndPortStr)
-      LOGDEBUG("Peer connection (INBOUND non-handshaked) (" + this->addressAndPortStr() + ") error (" +
-                func + ", " + std::to_string(ec.value()) + "): " + ec.message());
+      LOGXTRACE(
+        "Peer connection (INBOUND non-handshaked) (" + this->addressAndPortStr() + ") error (" +
+        func + ", " + std::to_string(ec.value()) + "): " + ec.message()
+      );
     }
 
     // Close the socket.
@@ -399,7 +403,7 @@ namespace P2P {
       peerStr = this->addressAndPortStr() + " (INBOUND non-handshaked)";
     }
 
-    LOGTRACE("Closing peer connection: " + peerStr + " (reason: " + reason + ")");
+    LOGXTRACE("Closing peer connection: " + peerStr + " (reason: " + reason + ")");
 
     boost::system::error_code ec;
 

--- a/src/utils/finalizedblock.cpp
+++ b/src/utils/finalizedblock.cpp
@@ -14,7 +14,7 @@ See the LICENSE.txt file in the project root for more information.
 FinalizedBlock FinalizedBlock::fromBytes(const bytes::View bytes, const uint64_t& requiredChainId) {
   try {
     // Verify minimum size for a valid block
-    SLOGTRACE("Deserializing block...");
+    SLOGXTRACE("Deserializing block...");
     if (bytes.size() < 217) throw std::length_error("Invalid block size - too short");
 
     // Parsing fixed-size fields
@@ -27,7 +27,7 @@ FinalizedBlock FinalizedBlock::fromBytes(const bytes::View bytes, const uint64_t
     uint64_t nHeight = UintConv::bytesToUint64(bytes.subspan(201, 8));
     uint64_t txValidatorStart = UintConv::bytesToUint64(bytes.subspan(209, 8));
 
-    SLOGTRACE("Deserializing transactions...");
+    SLOGXTRACE("Deserializing transactions...");
 
     std::vector<TxBlock> txs;
     std::vector<TxValidator> txValidators;


### PR DESCRIPTION
`requestValidatorTxs(nodeId)` is a blocking call that uses ~0 CPU, so added a large async-task thread pool to `Consensus` so that a validator node can actively pull validatorTxs in parallel from its peers.