### PR TITLE
Parallelize requestValidatorTxs() requests to peers (simpler version)

### DIFF
--- a/src/core/consensus.h
+++ b/src/core/consensus.h
@@ -24,6 +24,11 @@ class Consensus : public Log::LogicalLocationProvider {
     std::atomic<bool> stop_ = false; ///< Flag for stopping the consensus processing.
 
     /**
+     * Pull all validator votes known by all direct peers and into the blockchain state.
+     */
+    void requestValidatorTxsFromAllPeers();
+
+    /**
      * Create and broadcast a Validator block (called by validatorLoop()).
      * If the node is a Validator and it has to create a new block,
      * this function will be called, the new block will be created based on the


### PR DESCRIPTION
This is a simple patch that parallelizes requestValidatorTxs() calls in Consensus to each peer, instead of querying all peers serially, reducing latency from the sum of RTTs with all peers to the worst RTT among all peers.

Passes `[state],[rdpos]` unit tests (ran 100 times). Average block time (interval) using the `AIO-setup.sh` local testnet is about 200ms.